### PR TITLE
Fix an error in clean tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
 		"release:firefox": "cd distribution && web-ext-submit",
 		"start:chrome": "web-ext run --target=chromium",
 		"start:firefox": "web-ext run",
-		"test": "run-s lint:* build",
+		"pretest": "npm run build:packages",
+		"test": "run-s lint build",
 		"watch:packages": "node ./bin/packages/watch.js",
 		"watch:source": "wp-scripts start",
 		"watch": "npm-run-all build:packages --parallel watch:*"


### PR DESCRIPTION
When running tests in a clean environment, `lint` fails, as it can't find the `@wordpress/wxr` package, since that hasn't been built yet.

Building packages before linting solves this.