### PR TITLE
Add Media Library support

### DIFF
--- a/packages/wxr/src/index.js
+++ b/packages/wxr/src/index.js
@@ -17,6 +17,8 @@ export default class WXR {
 	constructor() {
 		this.wxr = create();
 
+		this.postIdCounter = 0;
+
 		this.addHeader();
 
 		this.channel = this.wxr
@@ -325,6 +327,12 @@ export default class WXR {
 				cdata: true,
 				filter: ( data ) => data.toString(),
 			},
+			{
+				key: 'attachment_url',
+				element: 'wp:attachment_url',
+				cdata: true,
+				filter: ( data ) => data.toString(),
+			},
 		];
 
 		const postEl = this.channel.ele( 'item' );
@@ -337,6 +345,12 @@ export default class WXR {
 				} else {
 					postEl.ele( filter.element, filter.attributes ).txt( data );
 				}
+			} else if ( 'id' === filter.key ) {
+				// There was no post ID passed, so let's use our internal counter.
+				postEl
+					.ele( filter.element, filter.attributes )
+					.txt( this.postIdCounter );
+				this.postIdCounter++;
 			}
 		} );
 

--- a/source/content.js
+++ b/source/content.js
@@ -56,11 +56,14 @@ const code = `
 
 		tries++;
 
-		if ( window.__INITIAL_STATE__ ) {
+		if ( window.__INITIAL_STATE__ && window.__MEDIA_TOKEN__ ) {
 			// To communicate back to content.js, use window.postMessage().
 			realPostMessage( {
 				type: 'save_wix_config',
-				data: window.__INITIAL_STATE__,
+				data: {
+					initialState: window.__INITIAL_STATE__,
+					mediaToken: window.__MEDIA_TOKEN__,
+				},
 			}, '*' );
 
 			clearInterval( intervalId )

--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -117,7 +117,7 @@ export const settings = {
 			} )
 		);
 
-		posts.forEach( ( post, postId ) => {
+		posts.forEach( ( post ) => {
 			const postAuthor = post.owner;
 			// If we haven't already added this author, we need to add them now.
 			if ( ! addedAuthors.includes( postAuthor.siteMemberId ) ) {
@@ -155,7 +155,6 @@ export const settings = {
 			}
 
 			wxr.addPost( {
-				id: postId,
 				guid: post.id,
 				author: postAuthor.slug,
 				date: post.firstPublishedDate,

--- a/source/services/wix/extractors/index.js
+++ b/source/services/wix/extractors/index.js
@@ -1,7 +1,12 @@
 import { settings as communitiesBlogAppSettings } from './communities-blog-app';
 import { settings as siteMetaSettings } from './site-meta-app';
+import { settings as mediaManagerSettings } from './media-manager';
 
 /**
  * An array of the defined extractors.
  */
-export const extractors = [ siteMetaSettings, communitiesBlogAppSettings ];
+export const extractors = [
+	siteMetaSettings,
+	communitiesBlogAppSettings,
+	mediaManagerSettings,
+];

--- a/source/services/wix/extractors/media-manager/index.js
+++ b/source/services/wix/extractors/media-manager/index.js
@@ -1,0 +1,72 @@
+export const settings = {
+	/**
+	 * The Wix application ID.
+	 */
+	appId: 'media-manager',
+
+	/**
+	 * This function will be called once the extraction process has started.
+	 *
+	 * @param {string} mediaToken The site media token.
+	 */
+	extract: async ( mediaToken ) => {
+		const checkFolders = [ 'media-root' ];
+		const knownFolders = [];
+
+		const fileListPromises = [];
+
+		while ( checkFolders.length > 0 ) {
+			const currentFolder = checkFolders.pop();
+			knownFolders.push( currentFolder );
+
+			fileListPromises.push(
+				window
+					.fetch(
+						`https://files.wix.com/go/site/media/files/list?site_token=${ mediaToken }&page_size=50&parent_folder_id=${ currentFolder }&media_type=picture,video,music,document,shape,site_icon,archive,swf`,
+						{
+							credentials: 'include',
+						}
+					)
+					.then( ( result ) => result.json() )
+					.then( ( fileData ) => fileData.files )
+			);
+
+			const folders = await window
+				.fetch(
+					`https://files.wix.com/go/site/media/folders/list?site_token=${ mediaToken }&page_size=50&parent_folder_id=${ currentFolder }`,
+					{
+						credentials: 'include',
+					}
+				)
+				.then( ( result ) => result.json() );
+
+			if ( Array.isArray( folders.folders ) ) {
+				folders.folders.forEach( ( folder ) => {
+					checkFolders.push( folder.folder_id );
+				} );
+			}
+		}
+
+		const fileList = await Promise.all( fileListPromises );
+
+		return fileList.flat();
+	},
+
+	/**
+	 * This function is called once we're ready to start generating the WXR file.
+	 *
+	 * @param {Object} files The file list returned by the extract() function.
+	 * @param {Object} wxr The WXR encoder.
+	 */
+	save: async ( files, wxr ) => {
+		files.forEach( ( file ) => {
+			wxr.addPost( {
+				guid: `https://static.wixstatic.com/${ file.file_url }`,
+				date: file.created_ts,
+				title: file.original_file_name,
+				type: 'attachment',
+				attachment_url: `https://static.wixstatic.com/${ file.file_url }`,
+			} );
+		} );
+	},
+};

--- a/source/services/wix/extractors/media-manager/index.js
+++ b/source/services/wix/extractors/media-manager/index.js
@@ -60,13 +60,23 @@ export const settings = {
 	 */
 	save: async ( files, wxr ) => {
 		files.forEach( ( file ) => {
-			wxr.addPost( {
-				guid: `https://static.wixstatic.com/${ file.file_url }`,
-				date: file.created_ts,
-				title: file.original_file_name,
-				type: 'attachment',
-				attachment_url: `https://static.wixstatic.com/${ file.file_url }`,
-			} );
+			if ( file.media_type === 'video' ) {
+				wxr.addPost( {
+					guid: `https://video.wixstatic.com/${ file.file_output.video[ 0 ].url }`,
+					date: file.created_ts * 1000,
+					title: file.original_file_name,
+					type: 'attachment',
+					attachment_url: `https://video.wixstatic.com/${ file.file_output.video[ 0 ].url }`,
+				} );
+			} else {
+				wxr.addPost( {
+					guid: `https://static.wixstatic.com/${ file.file_url }`,
+					date: file.created_ts * 1000,
+					title: file.original_file_name,
+					type: 'attachment',
+					attachment_url: `https://static.wixstatic.com/${ file.file_url }`,
+				} );
+			}
 		} );
 	},
 };

--- a/source/services/wix/index.js
+++ b/source/services/wix/index.js
@@ -19,19 +19,25 @@ export const startExport = async ( config ) => {
 	await Promise.all(
 		extractors.map( async ( extractor ) => {
 			// Grab the config data for this extractor.
-			const extractorConfig = Object.values(
-				config.embeddedServices
-			).reduce( ( found, appConfig ) => {
-				if ( found ) {
-					return found;
-				}
+			let extractorConfig;
 
-				if ( appConfig.applicationId === extractor.appId ) {
-					return appConfig;
-				}
+			if ( extractor.appId === 'media-manager' ) {
+				extractorConfig = config.mediaToken;
+			} else {
+				extractorConfig = Object.values(
+					config.initialState.embeddedServices
+				).reduce( ( found, appConfig ) => {
+					if ( found ) {
+						return found;
+					}
 
-				return false;
-			}, false );
+					if ( appConfig.applicationId === extractor.appId ) {
+						return appConfig;
+					}
+
+					return false;
+				}, false );
+			}
 
 			// Run the extractor.
 			const extractedData = await extractor.extract( extractorConfig );


### PR DESCRIPTION
This PR adds support for the Wix Media Manager.

Since the Media Manager functionality appears to run slightly separately from the Dashboard, it isn't defined as a regular app, so requires a little bit of custom handling.

It's worth noting that, due to limitations in WXR, we're not able to grab the original file upload as yet. Instead, we grab the version of the file that Wix embeds.

The primary downside of this approach is that videos have a maximum quality of 1080p. If a higher resolution file was uploaded, the 1080p version will be downloaded when the WXR file is imported into WordPress.

Once WXR supports having the media files embedded, a future iteration of this feature can download the original file, instead.

See #6.