### PR TITLE
Improve the Getting Started documentation

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+    "default": true,
+    "MD003": { "style": "atx" },
+    "MD004": { "style": "dash" },
+    "MD007": { "indent": 4 },
+    "MD013": { "line_length": 9999 },
+    "MD029": { "style": "ordered" },
+    "MD033": { "allowed_elements": [ "span" ] },
+    "MD035": { "style": "---" },
+    "MD048": { "style": "backtick" }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to WordPress' *Free (as in Freedom)* project! We hope you join us in helping folks free their content from CMSes that try to lock them in; all are welcome here.
 
-## How can I contribute?
+## How To Contribute
 
 To learn all about contributing to the *Free (as in Freedom)* project, see the [Contributor Guide](/docs/contributors/readme.md). The handbook includes all the details you need to get setup and start shaping the future of web publishing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,19 @@
 
 Welcome to WordPress' *Free (as in Freedom)* project! We hope you join us in helping folks free their content from CMSes that try to lock them in; all are welcome here.
 
-## Building and Testing
+## How can I contribute?
 
-*Free (as in Freedom)* is built using the current [Node](https://nodejs.org/en/) LTS version, and the latest version of [NPM](https://www.npmjs.com/). The easiest way to install these is with [NVM](https://github.com/nvm-sh/nvm).
+To learn all about contributing to the *Free (as in Freedom)* project, see the [Contributor Guide](/docs/contributors/readme.md). The handbook includes all the details you need to get setup and start shaping the future of web publishing.
 
-Running `npm run watch` will build the extension, and automatically rebuild it when changes are made.
+- Code? See the [developer section](/docs/contributors/develop.md).
 
-`npm run start:firefox` will open a new Firefox window with a fresh profile, install the extension, and automatically reload it when it rebuilds. `npm run start:chrome` will do the same in Chrome.
+- Design? See the [design section](/docs/contributors/design.md).
 
 ## Guidelines
 
 - As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
-- All WordPress projects are [licensed under the GPLv2+](/LICENSE.md), and all contributions to Gutenberg will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license.
+- All WordPress projects are [licensed under the GPLv2+](/LICENSE.md), and all contributions to *Free (as in Freedom)* will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license.
 
 ## Reporting Security Issues
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -98,17 +98,14 @@ portion of it, thus forming a work based on the Program, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
 
-  
 **a)** You must cause the modified files to carry prominent notices
 stating that you changed the files and the date of any change.
 
-  
 **b)** You must cause any work that you distribute or publish, that in
 whole or in part contains or is derived from the Program or any part
 thereof, to be licensed as a whole at no charge to all third parties
 under the terms of this License.
 
-  
 **c)** If the modified program normally reads commands interactively
 when run, you must cause it, when started running for such interactive
 use in the most ordinary way, to print or display an announcement
@@ -145,12 +142,10 @@ the scope of this License.
 under Section 2) in object code or executable form under the terms of
 Sections 1 and 2 above provided that you also do one of the following:
 
-  
 **a)** Accompany it with the complete corresponding machine-readable
 source code, which must be distributed under the terms of Sections 1
 and 2 above on a medium customarily used for software interchange; or,
 
-  
 **b)** Accompany it with a written offer, valid for at least three
 years, to give any third party, for a charge no more than your cost of
 physically performing source distribution, a complete machine-readable
@@ -158,7 +153,6 @@ copy of the corresponding source code, to be distributed under the
 terms of Sections 1 and 2 above on a medium customarily used for
 software interchange; or,
 
-  
 **c)** Accompany it with the information you received as to the offer
 to distribute corresponding source code. (This alternative is allowed
 only for noncommercial distribution and only if you received the

--- a/README.md
+++ b/README.md
@@ -1,11 +1,31 @@
 # Free (as in Speech)
 
-> You own the content you create. This browser extension helps you extract your content from CMSes that try to lock you in.
+> You own the content you create. When a CMS tries to lock you in, this extension helps you break free.
+
+Welcome to the *Free (as in Speech)* development hub! *FaiS* is a browser extension written for Firefox and Chrome, which allows you to export your site from Content Management Systems that don't otherwise provide you with an export.
 
 ## Getting Started
 
-*Free (as in Speech)* is an open-source project and welcomes all contributors from code to design, from documentation to triage. We'd love your help building it!
+### Using Free (as in Speech)
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the contributing guidelines.
+*FaiS* is currently under heavy development, and isn't recommended for general use. If you're comfortable with building software from source, you're welcome to experiment with it, but please be aware that it may not function as expected for you.
 
-As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+If you do try out *FaiS*, please let us know how you go! We love to hear feedback from everyone.
+
+### Contribute to Free (as in Speech)
+
+*FaiS* is an open-source project and welcomes all contributors from code to design, from documentation to triage. We'd love your help building it!
+
+See the [Contributing Guidelines](/CONTRIBUTING.md) for information on getting started.
+
+As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/ODE_OF_CONDUCT.md).
+
+## Get Involved
+
+You can join us in the `#core-importers` channel in Slack, see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information; it is free to join.
+
+## License
+
+WordPress is free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE.md](/LICENSE.md) for the complete license.
+
+<span style="display: block; margin-top: 4em; text-align: center;">![Code is Poetry.](https://s.w.org/style/images/codeispoetry.png)</span>

--- a/docs/contributors/design.md
+++ b/docs/contributors/design.md
@@ -8,7 +8,7 @@ The [Make WordPress Design blog](https://make.wordpress.org/design/) is the prim
 
 Real-time discussions for design take place in the `#design` channel in [Make WordPress Slack](https://make.wordpress.org/chat) (registration required). Weekly meetings for the Design team are on Wednesdays at 19:00UTC.
 
-## How Can Designers Contribute?
+## How Designers Can Contribute
 
 The *Free (as in Speech)* project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/pento/free-as-in-speech/](https://github.com/pento/free-as-in-speech/).
 

--- a/docs/contributors/design.md
+++ b/docs/contributors/design.md
@@ -1,0 +1,17 @@
+# Design Contributions
+
+A guide on how to get started contributing design to the *Free (as in Speech)* project.
+
+## Discussions
+
+The [Make WordPress Design blog](https://make.wordpress.org/design/) is the primary spot for the latest information around WordPress Design Team: including announcements, product goals, meeting notes, meeting agendas, and more.
+
+Real-time discussions for design take place in the `#design` channel in [Make WordPress Slack](https://make.wordpress.org/chat) (registration required). Weekly meetings for the Design team are on Wednesdays at 19:00UTC.
+
+## How Can Designers Contribute?
+
+The *Free (as in Speech)* project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/pento/free-as-in-speech/](https://github.com/pento/free-as-in-speech/).
+
+If you'd like to contribute to the design of this project, feel free to contribute to tickets labeled [Needs Design](https://github.com/pento/free-as-in-speech/issues?q=is%3Aissue+is%3Aopen+label%3A%22Needs+Design%22) or [Needs Design Feedback](https://github.com/pento/free-as-in-speech/issues?q=is%3Aissue+is%3Aopen+label%3A"Needs+Design+Feedback%22). We could use your thoughtful replies, mockups, animatics, sketches, doodles. Proposed changes are best done as minimal and specific iterations on the work that precedes it so we can compare.
+
+The [WordPress Design team](http://make.wordpress.org/design/) uses [Figma](https://www.figma.com/) to collaborate and share work. If you'd like to contribute, join the [#design channel](http://wordpress.slack.com/messages/design/) in [Slack](https://make.wordpress.org/chat/) and ask the team to set you up with a free Figma account. This will give you access to a helpful [library of components](https://www.figma.com/file/ZtN5xslEVYgzU7Dd5CxgGZwq/WordPress-Components?node-id=0%3A1) used in WordPress.

--- a/docs/contributors/develop.md
+++ b/docs/contributors/develop.md
@@ -1,0 +1,17 @@
+# Code Contributions
+
+A guide on how to get started contributing code to the *Free (as in Speech)* project.
+
+## Discussions
+
+Real-time discussions for development takes place in `#core-importers` channel in [Make WordPress Slack](https://make.wordpress.org/chat) (registration required).
+
+## Development Hub
+
+The *Free (as in Speech)* project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/pento/free-as-in-speech](https://github.com/pento/free-as-in-speech).
+
+Browse [the issues list](https://github.com/pento/free-as-in-speech/issues) to find issues to work on. The [good first issue](https://github.com/pento/free-as-in-speech/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) and [good first review](https://github.com/pento/free-as-in-speech/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) labels are good starting points.
+
+## Contributor Resources
+
+* [Getting Started](/docs/contributors/getting-started.md) documents getting your development environment setup, this includes your test site and developer tools suggestions.

--- a/docs/contributors/develop.md
+++ b/docs/contributors/develop.md
@@ -14,4 +14,4 @@ Browse [the issues list](https://github.com/pento/free-as-in-speech/issues) to f
 
 ## Contributor Resources
 
-* [Getting Started](/docs/contributors/getting-started.md) documents getting your development environment setup, this includes your test site and developer tools suggestions.
+[Getting Started](/docs/contributors/getting-started.md) documents getting your development environment setup, this includes your test site and developer tools suggestions.

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -1,0 +1,24 @@
+# Getting Started
+
+The following guide is for setting up your local environment to contribute to the *Free (as in Speech)* project.
+
+## Development Tools (Node)
+
+*Free (as in Speech)* is a JavaScript project and requires [Node.js](https://nodejs.org/). The project is built using the latest active LTS release of node, and the latest version of NPM. See the [LTS release schedule](https://github.com/nodejs/Release#release-schedule) for details.
+
+We recommend using the [Node Version Manager](https://github.com/nvm-sh/nvm) (nvm) since it is the easiest way to install and manage node for macOS, Linux, and Windows 10 using WSL2.
+
+After installing Node, you can build *Free (as in Speech)* by running the following from within the cloned repository:
+
+```bash
+npm ci
+npm run build
+```
+
+Once built, *Free (as in Speech)* can be loaded in your browser as a development extension!
+
+`npm run build` creates a single build of the project once. While developing, you probably will want to use `npm run watch` to run continuous builds automatically as source files change. The dev build also includes additional warnings and errors to help troubleshoot while developing.
+
+## Local Environment
+
+Whilst you can run the extension within your normal browser, it's usually better to use a clean browser profile for development. You'll need to have [Chrome](https://www.google.com/chrome/) or [Firefox](https://www.mozilla.org/firefox/new/) installed, you can then start a fresh copy of either of them by running `npm run start:chrome` or `npm run start:firefox`, respectively.

--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -1,0 +1,17 @@
+# Contributor Guide
+
+Welcome to the *Free (as in Speech)* Project Contributor Guide. This guide is here to help you get setup and start contributing to the project. If you have any questions, you'll find us in the `#core-importers` channel in the WordPress Core Slack, [free to join](https://make.wordpress.org/chat/).
+
+*Free (as in Speech)* is a sub-project of Core WordPress. Please see the [Core Contributor Handbook](https://make.wordpress.org/core/handbook/) for additional information.
+
+## Sections
+
+Find the section below based on what you are looking to contribute:
+
+- **Code?** See the [developer section](/docs/contributors/develop.md).
+
+- **Design?** See the [design section](/docs/contributors/design.md).
+
+## Guidelines
+
+See the [Contributing Guidelines](/CONTRIBUTING.md) for the rules around contributing: This includes the code of conduct and licensing information.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,8 @@
+# Upcoming Projects & Roadmap
+
+This document outlines some of the features currently in development or being considered for the project. It should not be confused with the product roadmap for WordPress itself, even if some areas naturally overlap. The main purpose of it is to give visibility to some of the key problems remaining to be solved and as an invitation for those wanting to collaborate on some of the more complex issues to learn about what needs help.
+
+## Projects
+
+- **WXR Library** — Create a standard library for handling WXR files. ([See overview](https://github.com/pento/free-as-in-speech/issues/3).)
+- **Wix Exporting** — Our primary focus is currently to produce an MVP of a Wix exporter. ([See overview](https://github.com/pento/free-as-in-speech/issues/6).)

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
 			"chromiumProfile": "./test/web-ext-profile",
 			"startUrl": [
 				"https://www.wix.com"
-			],
-			"browserConsole": true
+			]
 		}
 	}
 }

--- a/packages/wxr/README.md
+++ b/packages/wxr/README.md
@@ -10,4 +10,4 @@ Install the module
 npm install @wordpress/wxr --save-dev
 ```
 
-![Code is Poetry.](https://s.w.org/style/images/codeispoetry.png)
+<span style="display: block; margin-top: 4em; text-align: center;">![Code is Poetry.](https://s.w.org/style/images/codeispoetry.png)</span>


### PR DESCRIPTION
This PR is focussed on setting up the Getting Started documentation.

Content is liberally based on the same documentation found in the Gutenberg repo, but modified to fit our needs.

