### PR TITLE
Fix a couple of JS errors

### DIFF
--- a/source/services/wix/extractors/media-manager/index.js
+++ b/source/services/wix/extractors/media-manager/index.js
@@ -49,7 +49,8 @@ export const settings = {
 
 		const fileList = await Promise.all( fileListPromises );
 
-		return fileList.flat();
+		// If a folder is empty, it will result in a 'null' file in the list. Remove them.
+		return fileList.flat().filter( ( file ) => file !== null );
 	},
 
 	/**

--- a/source/services/wix/index.js
+++ b/source/services/wix/index.js
@@ -39,6 +39,11 @@ export const startExport = async ( config ) => {
 				}, false );
 			}
 
+			// If we couldn't find any app config for this extractor, the app isn't enabled.
+			if ( ! extractorConfig ) {
+				return;
+			}
+
 			// Run the extractor.
 			const extractedData = await extractor.extract( extractorConfig );
 


### PR DESCRIPTION
1. If there is no media in the media manager (or no media in a sub-folder), a 'null' file will be added to the file list: remove that before we try to process the file list.
2. If an app isn't enabled, there won't be any config for it. Skip extractors that we can't find corresponding app config for.