### PR TITLE
Revamp fetching the initial state for Wix

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -45,33 +45,33 @@ const code = `
 	// it's been loaded into Wix's redux store. In order to keep a copy before this happens, we intercept
 	// it right when the value is being set.
 
-	Object.defineProperty(window, '__INITIAL_STATE__', {
-		configurable: true,
+	Object.defineProperty( window, '__INITIAL_STATE__', {
+		configurable: true, // Needs to be true so that it can be deleted later.
 		get: function() {
 			return lastInitialState;
 		},
-		set: function(value) {
+		set: function( value ) {
 			if ( ! initialState ) {
 				initialState = Object.assign( {}, value );
 				sendMessage();
 			}
 			return lastInitialState = value;
 		}
-	});
+	} );
 
 	Object.defineProperty(window, '__MEDIA_TOKEN__', {
-		configurable: true,
+		configurable: true, // Needs to be true so that it can be deleted later.
 		get: function() {
 			return lastMediaToken;
 		},
-		set: function(value) {
+		set: function( value ) {
 			if ( ! mediaToken ) {
 				mediaToken = value;
 				sendMessage();
 			}
 			return lastMediaToken = value;
 		}
-	});
+	} );
 
 } )();
 `;

--- a/source/content.js
+++ b/source/content.js
@@ -41,6 +41,10 @@ const code = `
 
 	}
 
+	// window.__INITIAL_STATE__ is set when the page is loaded, but is subsequently deleted once
+	// it's been loaded into Wix's redux store. In order to keep a copy before this happens, we intercept
+	// it right when the value is being set.
+
 	Object.defineProperty(window, '__INITIAL_STATE__', {
 		configurable: true,
 		get: function() {


### PR DESCRIPTION
While debugging a missing instance header for an app, it seemed the racing to getting Wix's state before they delete it wasn't working. While reflecting now that the problem might have been elsewhere, I have created a (possibly) more robust implementation that is likely worth keeping.