### PR TITLE
Use the app definition id to match Wix apps

### DIFF
--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -5,9 +5,9 @@ import { serializeWixBlocksToWordPressBlocks } from './block-mapping';
 
 export const settings = {
 	/**
-	 * The Wix application ID.
+	 * The Wix application definition ID.
 	 */
-	appId: 10297,
+	appDefinitionId: '14bcded7-0066-7c35-14d7-466cb3f09103',
 
 	/**
 	 * This function will be called once the extraction process has started.

--- a/source/services/wix/extractors/media-manager/index.js
+++ b/source/services/wix/extractors/media-manager/index.js
@@ -1,8 +1,8 @@
 export const settings = {
 	/**
-	 * The Wix application ID.
+	 * The media manager doesn't have an app definition ID, we can use a fake one here.
 	 */
-	appId: 'media-manager',
+	appDefinitionId: 'media-manager',
 
 	/**
 	 * This function will be called once the extraction process has started.

--- a/source/services/wix/extractors/site-meta-app/index.js
+++ b/source/services/wix/extractors/site-meta-app/index.js
@@ -1,8 +1,8 @@
 export const settings = {
 	/**
-	 * The Wix application ID.
+	 * The Wix application definition ID.
 	 */
-	appId: -666,
+	appDefinitionId: '22bef345-3c5b-4c18-b782-74d4085112ff',
 
 	/**
 	 * This function will be called once the extraction process has started.

--- a/source/services/wix/index.js
+++ b/source/services/wix/index.js
@@ -21,7 +21,7 @@ export const startExport = async ( config ) => {
 			// Grab the config data for this extractor.
 			let extractorConfig;
 
-			if ( extractor.appId === 'media-manager' ) {
+			if ( extractor.appDefinitionId === 'media-manager' ) {
 				extractorConfig = config.mediaToken;
 			} else {
 				extractorConfig = Object.values(
@@ -34,10 +34,6 @@ export const startExport = async ( config ) => {
 					if (
 						appConfig.appDefinitionId === extractor.appDefinitionId
 					) {
-						return appConfig;
-					}
-
-					if ( appConfig.applicationId === extractor.appId ) {
 						return appConfig;
 					}
 

--- a/source/services/wix/index.js
+++ b/source/services/wix/index.js
@@ -31,6 +31,11 @@ export const startExport = async ( config ) => {
 						return found;
 					}
 
+					if ( appConfig.appDefinitionId === extractor.appDefinitionId ) {
+						return appConfig;
+					}
+
+
 					if ( appConfig.applicationId === extractor.appId ) {
 						return appConfig;
 					}

--- a/source/services/wix/index.js
+++ b/source/services/wix/index.js
@@ -31,10 +31,11 @@ export const startExport = async ( config ) => {
 						return found;
 					}
 
-					if ( appConfig.appDefinitionId === extractor.appDefinitionId ) {
+					if (
+						appConfig.appDefinitionId === extractor.appDefinitionId
+					) {
 						return appConfig;
 					}
-
 
 					if ( appConfig.applicationId === extractor.appId ) {
 						return appConfig;


### PR DESCRIPTION
Since we identified that our `applicationId`s are different between us, let's switch to using the `appDefinitionId`.