### PR TITLE
Test a WXR on a local WordPress

### DIFF
--- a/bin/test-wxr.sh
+++ b/bin/test-wxr.sh
@@ -16,6 +16,7 @@ else
 fi
 
 wp core install --url=$URL --title=wxr --admin_user=admin --skip-email --admin_email=example@example.com --path=wordpress
+wp option set permalink_structure "/%year%/%monthnum%/%day%/%postname%/" --path=wordpress
 wp plugin activate wordpress-importer --path=wordpress
 wp import "$1" --authors=create --path=wordpress
 php -S $URL -t wordpress

--- a/bin/test-wxr.sh
+++ b/bin/test-wxr.sh
@@ -1,0 +1,21 @@
+URL=wxr.wplocal.xyz:1234
+
+if [ ! -f "$1" ]; then
+	echo "$1 doesn't exist."
+	exit 1
+fi
+
+if [ ! -d wordpress ]; then
+	rm -rf wordpress
+	curl https://wordpress.org/latest.tar.gz | tar xz
+	curl https://raw.githubusercontent.com/aaemnnosttv/wp-sqlite-db/master/src/db.php > wordpress/wp-content/db.php
+	cp wordpress/wp-config{-sample,}.php
+	svn co https://plugins.svn.wordpress.org/wordpress-importer/trunk/ wordpress/wp-content/plugins/wordpress-importer/
+else
+	rm -rf wordpress/wp-content/database
+fi
+
+wp core install --url=$URL --title=wxr --admin_user=admin --skip-email --admin_email=example@example.com --path=wordpress
+wp plugin activate wordpress-importer --path=wordpress
+wp import "$1" --authors=create --path=wordpress
+php -S $URL -t wordpress


### PR DESCRIPTION
This adds a little shell script that can spool up a local WordPress using SQLite and import a specific WXR.

### Testing instructions
- Have a WXR handy, we have some in test/integration/*/fixtures
- so, for example, run `bin/test-wxr.sh test/integration/wix/fixtures/easyblog.wxr`

This will create a new directory `wordpress` and download the WordPress source, download SQLite integration, make it ready to use with a user `admin` (it will print the password) and import the WXR specified in the command. You can then open http://wxr.wplocal.xyz:1234/ and check how the WXR will import.

Example output:
```
Admin password: 
Success: WordPress installed successfully.
Plugin 'wordpress-importer' activated.
Success: Activated 1 of 1 plugins.
Starting the import process...
[...]
<p>All done. <a href="http://wxr.wplocal.xyz:1234/wp-admin/">Have fun!</a></p><p>Remember to update the passwords and roles of imported users.</p>
Success: Finished importing from 'test/integration/wix/fixtures/easyblog.wxr' file.
[Tue Mar  2 13:41:33 2021] PHP 7.4.15 Development Server (http://wxr.wplocal.xyz:1234) started
```