### PR TITLE
Add paging support to the Community Blog extractor

### DIFF
--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -29,10 +29,11 @@ module.exports = {
 				let offset = 0;
 				const pageSize = 500;
 
-				let page;
 				let totalPosts;
 
 				do {
+					let page;
+
 					try {
 						const response = await window.fetch(
 							`https://manage.wix.com/_api/communities-blog-node-api/_api/posts?offset=${ offset }&size=${ pageSize }&fieldsets=categories,owner,likes,content,subscriptions,tags&status=${ status }`,
@@ -74,35 +75,97 @@ module.exports = {
 				return { assignees: [] };
 			} );
 
-		const categoriesPromise = window
-			.fetch(
-				'https://manage.wix.com/_api/communities-blog-node-api/_api/categories?offset=0&size=500',
-				{ headers: { instance: config.instance }, mode: 'same-origin' }
-			)
-			.then( ( result ) => result.json() )
-			.catch( () => [] );
+		// const categoriesPromise = window
+		// 	.fetch(
+		// 		'https://manage.wix.com/_api/communities-blog-node-api/_api/categories?offset=0&size=500',
+		// 		{ headers: { instance: config.instance }, mode: 'same-origin' }
+		// 	)
+		// 	.then( ( result ) => result.json() )
+		// 	.catch( () => [] );
 
-		const tagsQuery = {
-			paging: {
-				offset: 0,
-				limit: 500,
-			},
-		};
+		const categoriesPromise = ( async () => {
+			const categories = [];
 
-		const tagsPromise = window
-			.fetch(
-				'https://manage.wix.com/_api/communities-blog-node-api/v2/tags/query',
-				{
-					method: 'POST',
-					headers: { instance: config.instance },
-					mode: 'same-origin',
-					body: JSON.stringify( tagsQuery ),
+			let offset = 0;
+			const pageSize = 500;
+
+			let totalCategories;
+
+			do {
+				let page;
+
+				try {
+					const response = await window.fetch(
+						`https://manage.wix.com/_api/communities-blog-node-api/_api/categories?offset=${ offset }&size=${ pageSize }`,
+						{
+							headers: { instance: config.instance },
+							mode: 'same-origin',
+						}
+					);
+
+					totalCategories = response.headers.get(
+						'wix-socialblog-totalresults'
+					);
+
+					page = await response.json();
+				} catch ( error ) {
+					page = [];
 				}
-			)
-			.then( ( result ) => result.json() )
-			.catch( () => {
-				return { tags: [] };
-			} );
+
+				Array.prototype.push.apply( categories, page );
+
+				offset += pageSize;
+			} while ( offset + pageSize <= totalCategories );
+
+			return categories;
+		} )();
+
+		const tagsPromise = ( async () => {
+			const tags = [];
+
+			let offset = 0;
+			const pageSize = 500;
+
+			let totalTags;
+
+			do {
+				let page;
+
+				const tagsQuery = {
+					paging: {
+						offset: 0,
+						limit: pageSize,
+					},
+				};
+
+				try {
+					const response = await window.fetch(
+						'https://manage.wix.com/_api/communities-blog-node-api/v2/tags/query',
+						{
+							method: 'POST',
+							headers: {
+								instance: config.instance,
+								'Content-Type': 'application/json',
+							},
+							mode: 'same-origin',
+							body: JSON.stringify( tagsQuery ),
+						}
+					);
+
+					page = await response.json();
+				} catch ( error ) {
+					page = { tags: [], metaData: { total: 0 } };
+				}
+
+				totalTags = page.metaData.total;
+
+				Array.prototype.push.apply( tags, page.tags );
+
+				offset += pageSize;
+			} while ( offset + pageSize <= totalTags );
+
+			return tags;
+		} )();
 
 		const [ posts, authors, categories, tags ] = await Promise.all( [
 			postsPromise,
@@ -115,7 +178,7 @@ module.exports = {
 			posts: posts.flat(),
 			authors: authors.assignees,
 			categories,
-			tags: tags.tags,
+			tags,
 		};
 	},
 

--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -55,7 +55,7 @@ module.exports = {
 					Array.prototype.push.apply( posts, page );
 
 					offset += pageSize;
-				} while ( offset + pageSize <= totalPosts );
+				} while ( offset < totalPosts );
 
 				return posts;
 			} )
@@ -115,7 +115,7 @@ module.exports = {
 				Array.prototype.push.apply( categories, page );
 
 				offset += pageSize;
-			} while ( offset + pageSize <= totalCategories );
+			} while ( offset < totalCategories );
 
 			return categories;
 		} )();
@@ -133,7 +133,7 @@ module.exports = {
 
 				const tagsQuery = {
 					paging: {
-						offset: 0,
+						offset,
 						limit: pageSize,
 					},
 				};
@@ -162,7 +162,7 @@ module.exports = {
 				Array.prototype.push.apply( tags, page.tags );
 
 				offset += pageSize;
-			} while ( offset + pageSize <= totalTags );
+			} while ( offset < totalTags );
 
 			return tags;
 		} )();

--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -75,14 +75,6 @@ module.exports = {
 				return { assignees: [] };
 			} );
 
-		// const categoriesPromise = window
-		// 	.fetch(
-		// 		'https://manage.wix.com/_api/communities-blog-node-api/_api/categories?offset=0&size=500',
-		// 		{ headers: { instance: config.instance }, mode: 'same-origin' }
-		// 	)
-		// 	.then( ( result ) => result.json() )
-		// 	.catch( () => [] );
-
 		const categoriesPromise = ( async () => {
 			const categories = [];
 

--- a/source/services/wix/extractors/communities-blog-app/test/index.js
+++ b/source/services/wix/extractors/communities-blog-app/test/index.js
@@ -58,3 +58,187 @@ test.each( data )( 'extract posts', async ( testData ) => {
 			expect( result ).toEqual( testData.extracted );
 		} );
 } );
+
+describe( 'extract()', () => {
+	beforeEach( () => fetchMock.reset() );
+
+	test( 'pages through posts', async () => {
+		const postPages = [
+			[
+				...Array( 500 )
+					.fill( 0 )
+					.map( ( value, id ) => ( { id } ) ),
+			],
+			[
+				...Array( 100 )
+					.fill( 0 )
+					.map( ( value, id ) => ( { id: id + 500 } ) ),
+			],
+		];
+
+		fetchMock
+			.mock( {
+				url:
+					'begin:https://manage.wix.com/_api/communities-blog-node-api/_api/posts?offset=0',
+				method: 'get',
+				query: { status: 'published' },
+				response: {
+					body: JSON.stringify( postPages[ 0 ] ),
+					headers: { 'wix-socialblog-totalresults': 600 },
+				},
+			} )
+			.mock( {
+				url:
+					'begin:https://manage.wix.com/_api/communities-blog-node-api/_api/posts?offset=500',
+				method: 'get',
+				query: { status: 'published' },
+				response: {
+					body: JSON.stringify( postPages[ 1 ] ),
+					headers: { 'wix-socialblog-totalresults': 600 },
+				},
+			} )
+			.mock( {
+				matcher:
+					'https://manage.wix.com/_serverless/assignee-service/assignees',
+				method: 'get',
+				response: JSON.stringify( { assignees: [] } ),
+			} )
+			.mock( {
+				matcher:
+					'https://manage.wix.com/_api/communities-blog-node-api/v2/tags/query',
+				method: 'post',
+				response: JSON.stringify( {
+					tags: [],
+					metaData: { total: 0 },
+				} ),
+			} )
+			.mock( '*', { body: '[]' } );
+
+		const result = await index.extract( { instance: 'test' } );
+
+		const expected = {
+			posts: [ ...postPages[ 0 ], ...postPages[ 1 ] ],
+			authors: [],
+			categories: [],
+			tags: [],
+		};
+
+		expect( result ).toEqual( expected );
+	} );
+
+	test( 'pages through categories', async () => {
+		const categoryPages = [
+			[
+				...Array( 500 )
+					.fill( 0 )
+					.map( ( value, id ) => ( { id } ) ),
+			],
+			[
+				...Array( 100 )
+					.fill( 0 )
+					.map( ( value, id ) => ( { id: id + 500 } ) ),
+			],
+		];
+
+		fetchMock
+			.mock( {
+				url:
+					'begin:https://manage.wix.com/_api/communities-blog-node-api/_api/categories?offset=0',
+				method: 'get',
+				response: {
+					body: JSON.stringify( categoryPages[ 0 ] ),
+					headers: { 'wix-socialblog-totalresults': 600 },
+				},
+			} )
+			.mock( {
+				url:
+					'begin:https://manage.wix.com/_api/communities-blog-node-api/_api/categories?offset=500',
+				method: 'get',
+				response: {
+					body: JSON.stringify( categoryPages[ 1 ] ),
+					headers: { 'wix-socialblog-totalresults': 600 },
+				},
+			} )
+			.mock( {
+				matcher:
+					'https://manage.wix.com/_serverless/assignee-service/assignees',
+				method: 'get',
+				response: JSON.stringify( { assignees: [] } ),
+			} )
+			.mock( {
+				matcher:
+					'https://manage.wix.com/_api/communities-blog-node-api/v2/tags/query',
+				method: 'post',
+				response: JSON.stringify( {
+					tags: [],
+					metaData: { total: 0 },
+				} ),
+			} )
+			.mock( '*', { body: '[]' } );
+
+		const result = await index.extract( { instance: 'test' } );
+
+		const expected = {
+			posts: [],
+			authors: [],
+			categories: [ ...categoryPages[ 0 ], ...categoryPages[ 1 ] ],
+			tags: [],
+		};
+
+		expect( result ).toEqual( expected );
+	} );
+
+	test( 'pages through tags', async () => {
+		const tagPages = [
+			[
+				...Array( 500 )
+					.fill( 0 )
+					.map( ( value, id ) => ( { id } ) ),
+			],
+			[
+				...Array( 100 )
+					.fill( 0 )
+					.map( ( value, id ) => ( { id: id + 500 } ) ),
+			],
+		];
+
+		fetchMock
+			.mock( {
+				matcher:
+					'https://manage.wix.com/_serverless/assignee-service/assignees',
+				method: 'get',
+				response: JSON.stringify( { assignees: [] } ),
+			} )
+			.mock( {
+				matcher:
+					'https://manage.wix.com/_api/communities-blog-node-api/v2/tags/query',
+				method: 'post',
+				response: ( url, options ) => {
+					let tags = [];
+					const body = JSON.parse( options.body );
+
+					if ( body.paging.offset === 0 ) {
+						tags = tagPages[ 0 ];
+					} else if ( body.paging.offset === 500 ) {
+						tags = tagPages[ 1 ];
+					}
+					return JSON.stringify( {
+						tags,
+						metaData: { total: 600 },
+					} );
+				},
+			} )
+			.mock( '*', { body: '[]' } );
+
+		const result = await index.extract( { instance: 'test' } );
+
+		const expected = {
+			posts: [],
+			authors: [],
+			categories: [],
+			tags: [ ...tagPages[ 0 ], ...tagPages[ 1 ] ],
+		};
+
+		expect( result ).toEqual( expected );
+	} );
+} );

--- a/source/services/wix/extractors/communities-blog-app/test/index.js
+++ b/source/services/wix/extractors/communities-blog-app/test/index.js
@@ -14,7 +14,10 @@ const data = [
 				name: 'bob',
 			},
 		],
-		tags: [],
+		tags: {
+			tags: [],
+			metaData: { total: 0 },
+		},
 		categories: [],
 		extracted: {},
 	},
@@ -22,7 +25,7 @@ const data = [
 data[ 0 ].extracted.posts = data[ 0 ].posts;
 data[ 0 ].extracted.authors = data[ 0 ].authors;
 data[ 0 ].extracted.categories = data[ 0 ].categories;
-data[ 0 ].extracted.tags = data[ 0 ].tags;
+data[ 0 ].extracted.tags = data[ 0 ].tags.tags;
 
 test.each( data )( 'extract posts', async ( testData ) => {
 	fetchMock
@@ -43,7 +46,7 @@ test.each( data )( 'extract posts', async ( testData ) => {
 			matcher:
 				'https://manage.wix.com/_api/communities-blog-node-api/v2/tags/query',
 			method: 'post',
-			response: JSON.stringify( { tags: testData.tags } ),
+			response: JSON.stringify( testData.tags ),
 		} )
 		.mock( '*', { body: '[]' } );
 

--- a/test/integration/wix/fixtures/wix-basic.har
+++ b/test/integration/wix/fixtures/wix-basic.har
@@ -92,6 +92,12 @@
           "status": 200,
           "statusText": "OK",
           "httpVersion": "HTTP/2",
+		  "headers": [
+			{
+				"name": "wix-socialblog-totalresults",
+				"value": "1"
+			}
+		  ],
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 2558,
@@ -148,6 +154,12 @@
           "status": 200,
           "statusText": "OK",
           "httpVersion": "HTTP/2",
+		  "headers": [
+			{
+				"name": "wix-socialblog-totalresults",
+				"value": "1"
+			}
+		  ],
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 2223,
@@ -204,6 +216,12 @@
           "status": 200,
           "statusText": "OK",
           "httpVersion": "HTTP/2",
+		  "headers": [
+			{
+				"name": "wix-socialblog-totalresults",
+				"value": "0"
+			}
+		  ],
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 2,

--- a/test/integration/wix/fixtures/wix-basic.har
+++ b/test/integration/wix/fixtures/wix-basic.har
@@ -309,6 +309,12 @@
           "status": 200,
           "statusText": "OK",
           "httpVersion": "HTTP/2",
+		  "headers": [
+			{
+				"name": "wix-socialblog-totalresults",
+				"value": "0"
+			}
+		  ],
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 2,
@@ -344,7 +350,7 @@
           "queryString": [],
           "headersSize": 3484,
           "postData": {
-            "mimeType": "text/plain;charset=UTF-8",
+            "mimeType": "application/json",
             "params": [],
             "text": "{\"paging\":{\"offset\":0,\"limit\":500}}"
           }


### PR DESCRIPTION
## Description

The community blog extractor currently exports the first 500 posts, categories, and tags.

This PR adds paging support, allowing it to export all data.

Fixes the last item in #6.

## How has this been tested?

- Tested in browser, reducing the page size to something more testable.
- Unit tests added.
