### PR TITLE
Test a WXR on a local WordPress

### DIFF
--- a/bin/test-wxr.sh
+++ b/bin/test-wxr.sh
@@ -16,6 +16,7 @@ else
 fi
 
 wp core install --url=$URL --title=wxr --admin_user=admin --skip-email --admin_email=example@example.com --path=wordpress
+wp option set permalink_structure "/%year%/%monthnum%/%day%/%postname%/" --path=wordpress
 wp plugin activate wordpress-importer --path=wordpress
 wp import "$1" --authors=create --path=wordpress
 php -S $URL -t wordpress

--- a/bin/test-wxr.sh
+++ b/bin/test-wxr.sh
@@ -1,0 +1,21 @@
+URL=wxr.wplocal.xyz:1234
+
+if [ ! -f "$1" ]; then
+	echo "$1 doesn't exist."
+	exit 1
+fi
+
+if [ ! -d wordpress ]; then
+	rm -rf wordpress
+	curl https://wordpress.org/latest.tar.gz | tar xz
+	curl https://raw.githubusercontent.com/aaemnnosttv/wp-sqlite-db/master/src/db.php > wordpress/wp-content/db.php
+	cp wordpress/wp-config{-sample,}.php
+	svn co https://plugins.svn.wordpress.org/wordpress-importer/trunk/ wordpress/wp-content/plugins/wordpress-importer/
+else
+	rm -rf wordpress/wp-content/database
+fi
+
+wp core install --url=$URL --title=wxr --admin_user=admin --skip-email --admin_email=example@example.com --path=wordpress
+wp plugin activate wordpress-importer --path=wordpress
+wp import "$1" --authors=create --path=wordpress
+php -S $URL -t wordpress

--- a/bin/test-wxr.sh
+++ b/bin/test-wxr.sh
@@ -1,9 +1,14 @@
-URL=wxr.wplocal.xyz:1234
+if [ "" == "$PORT" ]; then
+	PORT=1234
+fi
+URL=127.0.0.1:$PORT
+cd $(dirname $0)
 
 if [ ! -f "$1" ]; then
 	echo "$1 doesn't exist."
 	exit 1
 fi
+echo '<?php define("DB_FILE","'$PORT'.sqlite");' > $PORT.php
 
 if [ ! -d wordpress ]; then
 	rm -rf wordpress
@@ -12,11 +17,12 @@ if [ ! -d wordpress ]; then
 	cp wordpress/wp-config{-sample,}.php
 	svn co https://plugins.svn.wordpress.org/wordpress-importer/trunk/ wordpress/wp-content/plugins/wordpress-importer/
 else
-	rm -rf wordpress/wp-content/database
+	rm -f wordpress/wp-content/database/$PORT.sqlite
 fi
 
-wp core install --url=$URL --title=wxr --admin_user=admin --skip-email --admin_email=example@example.com --path=wordpress
-wp option set permalink_structure "/%year%/%monthnum%/%day%/%postname%/" --path=wordpress
-wp plugin activate wordpress-importer --path=wordpress
-wp import "$1" --authors=create --path=wordpress
-php -S $URL -t wordpress
+WP="wp --require=$PORT.php"
+$WP core install --url=$URL --title=wxr --admin_user=admin --admin_password=test --skip-email --admin_email=example@example.com --path=wordpress
+$WP option set permalink_structure "/%year%/%monthnum%/%day%/%postname%/" --path=wordpress
+$WP plugin activate wordpress-importer --path=wordpress
+$WP import "$1" --authors=create --path=wordpress
+php -dauto_prepend_file=`pwd`/$PORT.php -S $URL -t wordpress


### PR DESCRIPTION
An update of #29 to add support for additional ports as well as stripping the WXR from debug output that happens before the `<?xml`.

Putting this here for archiving as we decided we don't want to integrate something like this. It has proven useful for me to for comparing two imports.