### PR TITLE
Extract more attachments

### DIFF
--- a/source/services/wix/extractors/communities-blog-app/block-mapping.js
+++ b/source/services/wix/extractors/communities-blog-app/block-mapping.js
@@ -44,7 +44,10 @@ const blockMap = {
 					imageAttributes.rel = entity.data.link.rel;
 				}
 
-				if ( ! IdFactory.exists( entity.data.src.file_name ) ) {
+				if (
+					! IdFactory.exists( entity.data.src.file_name ) &&
+					undefined !== attachments
+				) {
 					attachments.push( {
 						id: IdFactory.get( entity.data.src.file_name ),
 						title: imageAttributes.alt || entity.data.src.file_name,

--- a/source/services/wix/extractors/communities-blog-app/block-mapping.js
+++ b/source/services/wix/extractors/communities-blog-app/block-mapping.js
@@ -3,6 +3,8 @@
  */
 const { createBlock, serialize } = require( '@wordpress/blocks' );
 const { applyFormat, create, toHTMLString } = require( '@wordpress/rich-text' );
+const IdFactory = require( '../../../../utils/idfactory.js' );
+const slug = require( 'slugify' );
 
 /**
  * The definition map for converting Wix blocks to WordPress blocks.
@@ -13,7 +15,7 @@ const { applyFormat, create, toHTMLString } = require( '@wordpress/rich-text' );
  * equivalent WordPress block.
  */
 const blockMap = {
-	atomic: ( block, { entityMap, ownerSiteMemberId } ) => {
+	atomic: ( block, { entityMap, ownerSiteMemberId }, attachments ) => {
 		if ( block.entityRanges.length === 0 ) {
 			// eslint-disable-next-line no-console
 			console.log( 'Entity block with no entity range', block );
@@ -27,6 +29,8 @@ const blockMap = {
 				const imageAttributes = {
 					url: `https://static.wixstatic.com/media/${ entity.data.src.file_name }`,
 					align: entity.data.config.alignment,
+					alt: null,
+					caption: null,
 				};
 
 				if ( entity.data.metadata ) {
@@ -38,6 +42,27 @@ const blockMap = {
 					imageAttributes.href = entity.data.link.url;
 					imageAttributes.linkTarget = entity.data.link.target;
 					imageAttributes.rel = entity.data.link.rel;
+				}
+
+				if ( ! IdFactory.exists( entity.data.src.file_name ) ) {
+					attachments.push( {
+						id: IdFactory.get( entity.data.src.file_name ),
+						title: imageAttributes.alt || entity.data.src.file_name,
+						excerpt: imageAttributes.caption || '',
+						content: imageAttributes.caption || '',
+						link: imageAttributes.url,
+						guid: imageAttributes.url,
+						commentStatus: 'closed',
+						name: slug( entity.data.src.file_name ),
+						type: 'attachment',
+						attachment_url: imageAttributes.url,
+						meta: [
+							{
+								key: '_wp_attachment_attachment_alt',
+								value: imageAttributes.alt || null,
+							},
+						],
+					} );
 				}
 
 				return createBlock( 'core/image', imageAttributes );
@@ -255,10 +280,10 @@ const formatText = ( block, entityMap ) => {
  *
  * @param {Object} wixBlocks The Wix blocks.
  * @param {Object} data      Additional post data.
- *
+ * @param {Object} attachments The attachments that were embedded in the block.
  * @return {string} The serialized WordPress blocks.
  */
-module.exports = ( wixBlocks, data ) => {
+module.exports = ( wixBlocks, data, attachments ) => {
 	let listType = '';
 	const listBuffer = [];
 
@@ -286,7 +311,11 @@ module.exports = ( wixBlocks, data ) => {
 				}
 
 				// We're at the last list item, process the list now.
-				const wpBlock = blockMap[ listType ]( listBuffer, data );
+				const wpBlock = blockMap[ listType ](
+					listBuffer,
+					data,
+					attachments
+				);
 
 				// Clean up the buffer.
 				listType = '';
@@ -296,7 +325,7 @@ module.exports = ( wixBlocks, data ) => {
 			}
 
 			if ( blockMap[ wixBlock.type ] ) {
-				return blockMap[ wixBlock.type ]( wixBlock, data );
+				return blockMap[ wixBlock.type ]( wixBlock, data, attachments );
 			}
 
 			// eslint-disable-next-line no-console

--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -245,6 +245,7 @@ module.exports = {
 				postContent = post.content;
 			}
 
+			const attachments = [];
 			wxr.addPost( {
 				guid: post.id,
 				author: postAuthor.slug,
@@ -255,7 +256,8 @@ module.exports = {
 					{
 						entityMap: postContent.entityMap,
 						ownerSiteMemberId: post.ownerSiteMemberId,
-					}
+					},
+					attachments
 				),
 				status: statusMap[ post.status ],
 				sticky: post.isPinned ? 1 : 0,
@@ -263,6 +265,8 @@ module.exports = {
 				comment_status: post.isCommentsDisabled ? 'closed' : 'open',
 				terms: [ ...postCategories, ...postTags ],
 			} );
+
+			attachments.forEach( ( attachment ) => wxr.addPost( attachment ) );
 		} );
 	},
 };

--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -211,7 +211,10 @@ module.exports = {
 		posts.forEach( ( post ) => {
 			const postAuthor = post.owner;
 			// If we haven't already added this author, we need to add them now.
-			if ( postAuthor.slug && ! addedAuthors.includes( postAuthor.slug ) ) {
+			if (
+				postAuthor.slug &&
+				! addedAuthors.includes( postAuthor.slug )
+			) {
 				addedAuthors.push( postAuthor.slug );
 
 				wxr.addAuthor( {

--- a/source/services/wix/extractors/communities-blog-app/index.js
+++ b/source/services/wix/extractors/communities-blog-app/index.js
@@ -211,7 +211,7 @@ module.exports = {
 		posts.forEach( ( post ) => {
 			const postAuthor = post.owner;
 			// If we haven't already added this author, we need to add them now.
-			if ( ! addedAuthors.includes( postAuthor.slug ) ) {
+			if ( postAuthor.slug && ! addedAuthors.includes( postAuthor.slug ) ) {
 				addedAuthors.push( postAuthor.slug );
 
 				wxr.addAuthor( {

--- a/source/services/wix/extractors/media-manager/index.js
+++ b/source/services/wix/extractors/media-manager/index.js
@@ -84,8 +84,13 @@ module.exports = {
 					attachment_url: `https://video.wixstatic.com/${ file.file_output.video[ 0 ].url }`,
 				} );
 			} else {
+				const filename = file.original_file_name || file.file_url;
+				if ( IdFactory.exists( filename ) ) {
+					return;
+				}
+
 				wxr.addPost( {
-					id: IdFactory.get( file.original_file_name ),
+					id: IdFactory.get( filename ),
 					guid: `https://static.wixstatic.com/${ file.file_url }`,
 					date: file.created_ts * 1000,
 					title: file.original_file_name,

--- a/source/services/wix/extractors/media-manager/index.js
+++ b/source/services/wix/extractors/media-manager/index.js
@@ -1,3 +1,5 @@
+const IdFactory = require( '../../../../utils/idfactory.js' );
+
 module.exports = {
 	/**
 	 * A name for the app, displayed to the user.
@@ -74,6 +76,7 @@ module.exports = {
 		files.forEach( ( file ) => {
 			if ( file.media_type === 'video' ) {
 				wxr.addPost( {
+					id: IdFactory.get( file.file_output.video[ 0 ].url ),
 					guid: `https://video.wixstatic.com/${ file.file_output.video[ 0 ].url }`,
 					date: file.created_ts * 1000,
 					title: file.original_file_name,
@@ -82,6 +85,7 @@ module.exports = {
 				} );
 			} else {
 				wxr.addPost( {
+					id: IdFactory.get( file.original_file_name ),
 					guid: `https://static.wixstatic.com/${ file.file_url }`,
 					date: file.created_ts * 1000,
 					title: file.original_file_name,

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -406,8 +406,6 @@ module.exports = {
 							.flat()
 							.filter( Boolean );
 
-						if ( component.id === 'comp-knesa40w' )
-							console.log( component, innerBlocks );
 						return createBlock( 'core/column', {}, innerBlocks );
 					}
 
@@ -420,20 +418,22 @@ module.exports = {
 						);
 
 						if (
-							innerBlocks.length > 1 &&
+							innerBlocks.length > 0 &&
 							'core/column' === innerBlocks[ 0 ].name
 						) {
-							// Real columns == more than 1.
-							return maybeAddCoverBlock(
-								component,
-								createBlock( 'core/columns', {}, innerBlocks )
-							);
-						}
-						if (
-							innerBlocks.length == 1 &&
-							'core/column' === innerBlocks[ 0 ].name
-						) {
-							// Not really a column, let's strip it.
+							if ( innerBlocks.length > 1 ) {
+								// Real columns == more than 1, we need to wrap it with a columns block.
+								return maybeAddCoverBlock(
+									component,
+									createBlock(
+										'core/columns',
+										{},
+										innerBlocks
+									)
+								);
+							}
+
+							// Just a single column, let's unwrap it.
 							innerBlocks = innerBlocks[ 0 ].innerBlocks;
 						}
 					} else {

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -242,6 +242,12 @@ module.exports = {
 	 * @param {Object} config The app-specific config extracted from the Wix page.
 	 */
 	extract: async ( config ) => {
+		const data = {
+			pages: [],
+			menus: [],
+			attachments: [],
+		};
+
 		const url = new URL(
 			'https://manage.wix.com/editor/' + config.metaSiteId
 		);
@@ -273,7 +279,7 @@ module.exports = {
 			undefined === metaData.siteHeader ||
 			undefined === metaData.siteHeader.pageIdList
 		) {
-			return [];
+			return data;
 		}
 
 		// This is used to construct a URL from the filename, see fetchPageJson().
@@ -301,15 +307,11 @@ module.exports = {
 			.catch( () => {} );
 
 		// Fetch the pages as Json.
-		const data = {
-			pages: await Promise.all(
-				metaData.siteHeader.pageIdList.pages.map(
-					fetchPageJson( topology, editorUrl )
-				)
-			),
-			menus: [],
-			attachments: [],
-		};
+		data.pages = await Promise.all(
+			metaData.siteHeader.pageIdList.pages.map(
+				fetchPageJson( topology, editorUrl )
+			)
+		);
 
 		data.pages.forEach( ( page ) => {
 			const parseComponent = ( component ) => {

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -401,39 +401,18 @@ module.exports = {
 						'wysiwyg.viewer.components.Column' ===
 						component.componentType
 					) {
-						const columns = {};
-						component.components.forEach( ( item ) => {
-							const comp = parseComponent( item );
-							if ( ! comp ) {
-								return;
-							}
-							const col = Math.floor( item.layout.x / 150 ) * 150;
-							if ( undefined === columns[ col ] ) {
-								columns[ col ] = [];
-							}
-							columns[ col ] = columns[ col ].concat( comp );
-						} );
 
-						if ( 1 === Object.values( columns ).length ) {
-							// Not real columns, let's just flatten this.
-							return maybeAddCoverBlock(
-								component,
-								Object.values( columns )
-									.flat()
-									.filter( Boolean )
-							);
-						}
+						innerBlocks = component.components
+							.map( parseComponent )
+							.flat()
+							.filter( Boolean );
 
-						innerBlocks = Object.values( columns ).map( ( items ) =>
-							createBlock( 'core/column', {}, items )
-						);
-					} else {
-						innerBlocks = maybeAddCoverBlock(
-							component,
-							component.components
-								.map( parseComponent )
-								.flat()
-								.filter( Boolean )
+							if ( component.id === 'comp-knesa40w' )
+						console.log( component,innerBlocks);
+						return createBlock(
+							'core/column',
+							{},
+							innerBlocks
 						);
 					}
 
@@ -441,16 +420,35 @@ module.exports = {
 						'wysiwyg.viewer.components.StripColumnsContainer' ===
 						component.componentType
 					) {
+						innerBlocks = component.components
+							.map( parseComponent );
+
 						if (
 							innerBlocks.length > 1 &&
 							'core/column' === innerBlocks[ 0 ].name
 						) {
-							innerBlocks = createBlock(
-								'core/columns',
-								{},
-								innerBlocks
+							// Real columns == more than 1.
+							return maybeAddCoverBlock(
+								component,
+								createBlock(
+									'core/columns',
+									{},
+									innerBlocks
+								)
 							);
 						}
+						if (
+							innerBlocks.length == 1 &&
+							'core/column' === innerBlocks[ 0 ].name
+						) {
+							// Not really a column, let's strip it.
+							innerBlocks = innerBlocks[0].innerBlocks;
+						}
+					} else {
+						innerBlocks = component.components
+							.map( parseComponent )
+							.flat()
+							.filter( Boolean );
 					}
 
 					return maybeAddCoverBlock( component, innerBlocks );

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -401,27 +401,23 @@ module.exports = {
 						'wysiwyg.viewer.components.Column' ===
 						component.componentType
 					) {
-
 						innerBlocks = component.components
 							.map( parseComponent )
 							.flat()
 							.filter( Boolean );
 
-							if ( component.id === 'comp-knesa40w' )
-						console.log( component,innerBlocks);
-						return createBlock(
-							'core/column',
-							{},
-							innerBlocks
-						);
+						if ( component.id === 'comp-knesa40w' )
+							console.log( component, innerBlocks );
+						return createBlock( 'core/column', {}, innerBlocks );
 					}
 
 					if (
 						'wysiwyg.viewer.components.StripColumnsContainer' ===
 						component.componentType
 					) {
-						innerBlocks = component.components
-							.map( parseComponent );
+						innerBlocks = component.components.map(
+							parseComponent
+						);
 
 						if (
 							innerBlocks.length > 1 &&
@@ -430,11 +426,7 @@ module.exports = {
 							// Real columns == more than 1.
 							return maybeAddCoverBlock(
 								component,
-								createBlock(
-									'core/columns',
-									{},
-									innerBlocks
-								)
+								createBlock( 'core/columns', {}, innerBlocks )
 							);
 						}
 						if (
@@ -442,7 +434,7 @@ module.exports = {
 							'core/column' === innerBlocks[ 0 ].name
 						) {
 							// Not really a column, let's strip it.
-							innerBlocks = innerBlocks[0].innerBlocks;
+							innerBlocks = innerBlocks[ 0 ].innerBlocks;
 						}
 					} else {
 						innerBlocks = component.components

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -4,7 +4,12 @@ const { pasteHandler, serialize } = require( '@wordpress/blocks' );
 const slug = require( 'slugify' );
 const IdFactory = require( '../../../../utils/idfactory.js' );
 
-const escHtml = ( text ) => String( text ).replace( /"/g, '&quot;' ).replace( /&/g, '&amp;' ).replace( />/g, '&gt;' ).replace( /</g, '&lt;' );
+const escHtml = ( text ) =>
+	String( text )
+		.replace( /"/g, '&quot;' )
+		.replace( /&/g, '&amp;' )
+		.replace( />/g, '&gt;' )
+		.replace( /</g, '&lt;' );
 
 const extractConfigData = ( html ) => {
 	const configData = {};
@@ -141,7 +146,6 @@ const parseMenu = ( menuItem, masterPage ) => {
 
 	return menu;
 };
-
 
 const resolveQueries = ( input, data ) => {
 	// skip resolving for non-objects
@@ -308,50 +312,64 @@ module.exports = {
 		};
 
 		data.pages.forEach( ( page ) => {
-			const parseComponent = (
-				component
-			) => {
-				component = resolveQueries( component, page.config.data ).dataQuery;
+			const parseComponent = ( component ) => {
+				component = resolveQueries( component, page.config.data )
+					.dataQuery;
 				if ( component ) {
-				switch ( component.type ) {
-					case 'Image':
-						if ( ! component.uri ) {
-							break;
-						}
+					switch ( component.type ) {
+						case 'Image':
+							if ( ! component.uri ) {
+								break;
+							}
 
-						component.src =
-							metaData.serviceTopology.staticMediaUrl + '/' + component.uri;
-						component.text = '<img src="' + escHtml( component.src ) + '" alt="' + escHtml( component.alt ) + '" width="' + escHtml( component.width ) + '" height="' + escHtml( component.height ) + '" />';
+							component.src =
+								metaData.serviceTopology.staticMediaUrl +
+								'/' +
+								component.uri;
+							component.text =
+								'<img src="' +
+								escHtml( component.src ) +
+								'" alt="' +
+								escHtml( component.alt ) +
+								'" width="' +
+								escHtml( component.width ) +
+								'" height="' +
+								escHtml( component.height ) +
+								'" />';
 
-						if ( IdFactory.exists( component.name ) ) {
+							if ( IdFactory.exists( component.name ) ) {
+								break;
+							}
+							data.attachments.push( {
+								id: IdFactory.get(
+									component.name || component.uri
+								),
+								title: component.alt,
+								excerpt: component.description || '',
+								content: component.description || '',
+								link: component.src,
+								guid: component.src,
+								commentStatus: 'closed',
+								name: slug( component.name || component.uri ),
+								type: 'attachment',
+								attachment_url: component.src,
+								meta: [
+									{
+										key: '_wp_attachment_attachment_alt',
+										value: component.alt || null,
+									},
+								],
+							} );
 							break;
-						}
-						data.attachments.push( {
-							id: IdFactory.get( component.name || component.uri ),
-							title: component.alt,
-							excerpt: component.description || '',
-							content: component.description || '',
-							link: component.src,
-							guid: component.src,
-							commentStatus: 'closed',
-							name: slug( component.name || component.uri ),
-							type: 'attachment',
-							attachment_url: component.src,
-							meta: [
-								{
-									key: '_wp_attachment_attachment_alt',
-									value: component.alt || null,
-								},
-							],
-						} );
-						break;
+					}
 				}
-			}
 
 				return component;
 			};
 
-			const components = page.config.structure.components.map(parseComponent);
+			const components = page.config.structure.components.map(
+				parseComponent
+			);
 
 			page.content = pasteHandler( {
 				HTML: components

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -315,8 +315,7 @@ module.exports = {
 
 		data.pages.forEach( ( page ) => {
 			const parseComponent = ( component ) => {
-				console.log(component.id)
-				component = resolveQueries( component, page.config.data )
+				component = resolveQueries( component, page.config.data );
 
 				if ( component.components ) {
 					// A container, so let's return the children.
@@ -376,9 +375,9 @@ module.exports = {
 				return component;
 			};
 
-			const components = page.config.structure.components.map(
-				parseComponent
-			).flat();
+			const components = page.config.structure.components
+				.map( parseComponent )
+				.flat();
 
 			page.content = pasteHandler( {
 				HTML: components

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -315,8 +315,15 @@ module.exports = {
 
 		data.pages.forEach( ( page ) => {
 			const parseComponent = ( component ) => {
+				console.log(component.id)
 				component = resolveQueries( component, page.config.data )
-					.dataQuery;
+
+				if ( component.components ) {
+					// A container, so let's return the children.
+					return component.components.map( parseComponent ).flat();
+				}
+
+				component = component.dataQuery;
 				if ( component ) {
 					switch ( component.type ) {
 						case 'Image':
@@ -371,7 +378,7 @@ module.exports = {
 
 			const components = page.config.structure.components.map(
 				parseComponent
-			);
+			).flat();
 
 			page.content = pasteHandler( {
 				HTML: components

--- a/source/utils/idfactory.js
+++ b/source/utils/idfactory.js
@@ -2,6 +2,13 @@ const ids = {};
 let counter = 0;
 
 module.exports = {
+	exists: ( idKey ) => {
+		const key = String( idKey ).replace( /^#/, '' );
+		if ( undefined === ids[ key ] ) {
+			return false;
+		}
+		return ids[ key ];
+	},
 	get: ( idKey ) => {
 		const key = String( idKey ).replace( /^#/, '' );
 		if ( undefined === ids[ key ] ) {


### PR DESCRIPTION
## Description
While we have been extracting attachments from the media library, there are more ways to embed images. We need to put them into attachments as well so that they are downloaded and re-linked upon import to WordPress.

## How has this been tested?
With my usual HAR file but it equally works through the extension.

## Screenshots
Before:

![Screenshot 2021-03-24 at 15 10 06](https://user-images.githubusercontent.com/203408/112324635-4b94a700-8cb3-11eb-97dc-d3aeef3ab4cc.png)

After:

![Screenshot 2021-03-24 at 15 07 43](https://user-images.githubusercontent.com/203408/112324657-50595b00-8cb3-11eb-87d3-69eb5d42a2b9.png)


## Types of changes
New Feature.