### PR TITLE
Wix: Add support for full-width blocks in the community blog app.

### DIFF
--- a/source/services/wix/extractors/communities-blog-app/block-mapping.js
+++ b/source/services/wix/extractors/communities-blog-app/block-mapping.js
@@ -43,12 +43,22 @@ const blockMap = {
 				return createBlock( 'core/image', imageAttributes );
 
 			case 'wix-draft-plugin-video':
+				const videoAttributes = {};
+
+				if ( entity.data.config ) {
+					if ( entity.data.config.size === 'fullWidth' ) {
+						videoAttributes.align = 'full';
+					} else {
+						videoAttributes.align = entity.data.config.alignment;
+					}
+				}
+
 				// Uploaded videos should be treated as video blocks.
 				if ( entity.data.isCustomVideo ) {
-					return createBlock( 'core/video', {
-						src: `https://video.wixstatic.com/${ entity.data.src.pathname }`,
-						poster: `https://static.wixstatic.com/${ entity.data.src.thumbnail.pathname }`,
-					} );
+					videoAttributes.src = `https://video.wixstatic.com/${ entity.data.src.pathname }`;
+					videoAttributes.poster = `https://static.wixstatic.com/${ entity.data.src.thumbnail.pathname }`;
+
+					return createBlock( 'core/video', videoAttributes );
 				}
 
 				// All other videos are some form of embed.

--- a/source/services/wix/extractors/communities-blog-app/block-mapping.js
+++ b/source/services/wix/extractors/communities-blog-app/block-mapping.js
@@ -29,6 +29,12 @@ const blockMap = {
 					align: entity.data.config.alignment,
 				};
 
+				if ( entity.data.config ) {
+					imageAttributes.align = extractWordPressAlignmentFromWixConfig(
+						entity.data.config
+					);
+				}
+
 				if ( entity.data.metadata ) {
 					imageAttributes.alt = entity.data.metadata.alt;
 					imageAttributes.caption = entity.data.metadata.caption;
@@ -46,11 +52,9 @@ const blockMap = {
 				const videoAttributes = {};
 
 				if ( entity.data.config ) {
-					if ( entity.data.config.size === 'fullWidth' ) {
-						videoAttributes.align = 'full';
-					} else {
-						videoAttributes.align = entity.data.config.alignment;
-					}
+					videoAttributes.align = extractWordPressAlignmentFromWixConfig(
+						entity.data.config
+					);
 				}
 
 				// Uploaded videos should be treated as video blocks.
@@ -64,22 +68,30 @@ const blockMap = {
 				// All other videos are some form of embed.
 				return createBlock( 'core/embed', {
 					url: entity.data.src,
-					align: entity.data.config.alignment,
+					align: extractWordPressAlignmentFromWixConfig(
+						entity.data.config
+					),
 				} );
 
 			case 'wix-draft-plugin-gallery':
-				const gallerySettings = {};
+				const galleryAttributes = {};
 
-				gallerySettings.images = entity.data.items.map( ( img ) => ( {
+				if ( entity.data.config ) {
+					galleryAttributes.align = extractWordPressAlignmentFromWixConfig(
+						entity.data.config
+					);
+				}
+
+				galleryAttributes.images = entity.data.items.map( ( img ) => ( {
 					url: `https://static.wixstatic.com/media/${ img.url }`,
 				} ) );
 
 				if ( entity.data.styles.numberOfImagesPerRow > 0 ) {
-					gallerySettings.columns =
+					galleryAttributes.columns =
 						entity.data.styles.numberOfImagesPerRow;
 				}
 
-				return createBlock( 'core/gallery', gallerySettings );
+				return createBlock( 'core/gallery', galleryAttributes );
 
 			case 'wix-draft-plugin-file-upload':
 				return createBlock( 'core/file', {
@@ -150,6 +162,20 @@ const blockMap = {
 			align: block.data.textAlignment,
 		} );
 	},
+};
+
+/**
+ * Given a Wix block config data blob, returns the appropriate alignment string for a WordPress block.
+ *
+ * @param {Object} config The Wix block config.
+ *
+ * @return {string} The alignment string.
+ */
+const extractWordPressAlignmentFromWixConfig = ( config ) => {
+	if ( config.size === 'fullWidth' ) {
+		return 'full';
+	}
+	return config.alignment;
 };
 
 /**

--- a/source/services/wix/extractors/communities-blog-app/test/__snapshots__/block-mapping.js.snap
+++ b/source/services/wix/extractors/communities-blog-app/test/__snapshots__/block-mapping.js.snap
@@ -81,8 +81,8 @@ exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles single images
 `;
 
 exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles uploaded videos 1`] = `
-"<!-- wp:video -->
-<figure class=\\"wp-block-video\\"><video controls poster=\\"https://static.wixstatic.com/media/video1_thumb.jpg\\" src=\\"https://video.wixstatic.com/video1.mp4\\"></video></figure>
+"<!-- wp:video {\\"align\\":\\"full\\"} -->
+<figure class=\\"wp-block-video alignfull\\"><video controls poster=\\"https://static.wixstatic.com/media/video1_thumb.jpg\\" src=\\"https://video.wixstatic.com/video1.mp4\\"></video></figure>
 <!-- /wp:video -->"
 `;
 

--- a/source/services/wix/extractors/communities-blog-app/test/__snapshots__/block-mapping.js.snap
+++ b/source/services/wix/extractors/communities-blog-app/test/__snapshots__/block-mapping.js.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles "unstyled" blocks as paragraphs 1`] = `
+"<!-- wp:paragraph -->
+<p>This is a paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is another paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles code blocks 1`] = `
+"<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code>This is some code
+It's possibly the best code I've ever written
+maybe.</code></pre>
+<!-- /wp:code -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles embedded videos 1`] = `
+"<!-- wp:embed {\\"url\\":\\"https://www.youtube.com/watch?v=RWf83UX4vKs\\",\\"align\\":\\"right\\"} -->
+<figure class=\\"wp-block-embed alignright\\"><div class=\\"wp-block-embed__wrapper\\">
+https://www.youtube.com/watch?v=RWf83UX4vKs
+</div></figure>
+<!-- /wp:embed -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles formatting in text 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <strong>bold</strong>, <em>italic</em>, <span style=\\"text-decoration: underline;\\">underlined</span>, <strong><span style=\\"text-decoration: underline;\\">and</span> <em>a combination</em></strong>.</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles heading blocks 1`] = `
+"<!-- wp:heading -->
+<h2>This is a h2</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {\\"level\\":3} -->
+<h3>This is a h3</h3>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles image galleries 1`] = `
+"<!-- wp:gallery {\\"columns\\":4} -->
+<figure class=\\"wp-block-gallery columns-4 is-cropped\\"><ul class=\\"blocks-gallery-grid\\"><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image2.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image3.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image4.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image5.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image6.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image7.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image8.png\\"/></figure></li></ul></figure>
+<!-- /wp:gallery -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles links in text 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <a href=\\"https://wordpress.org/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">a link</a>.</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles list items 1`] = `
+"<!-- wp:list {\\"ordered\\":true} -->
+<ol><li>Number one</li><li>Number two</li><li>Number three</li></ol>
+<!-- /wp:list -->
+
+<!-- wp:list -->
+<ul><li>First</li><li>Second</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:list {\\"ordered\\":true} -->
+<ol><li>Number one, second edition</li></ol>
+<!-- /wp:list -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles quote blocks 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>Use the source, Luke.</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles single images 1`] = `
+"<!-- wp:image {\\"align\\":\\"center\\"} -->
+<div class=\\"wp-block-image\\"><figure class=\\"aligncenter\\"><a href=\\"https://wordpress.org/\\" target=\\"_blank\\" rel=\\"noopener\\"><img src=\\"https://static.wixstatic.com/media/image1.png\\" alt=\\"image1 alt text\\"/></a><figcaption>image1 caption</figcaption></figure></div>
+<!-- /wp:image -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles uploaded videos 1`] = `
+"<!-- wp:video -->
+<figure class=\\"wp-block-video\\"><video controls poster=\\"https://static.wixstatic.com/media/video1_thumb.jpg\\" src=\\"https://video.wixstatic.com/video1.mp4\\"></video></figure>
+<!-- /wp:video -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks ignores underline formatting that matches a link 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <a href=\\"https://wordpress.org/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">a link</a>.</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks returns an empty string when passed no blocks 1`] = `""`;

--- a/source/services/wix/extractors/communities-blog-app/test/__snapshots__/block-mapping.js.snap
+++ b/source/services/wix/extractors/communities-blog-app/test/__snapshots__/block-mapping.js.snap
@@ -32,6 +32,18 @@ exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles formatting in
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles full-width image galleries 1`] = `
+"<!-- wp:gallery {\\"columns\\":2,\\"align\\":\\"full\\"} -->
+<figure class=\\"wp-block-gallery alignfull columns-2 is-cropped\\"><ul class=\\"blocks-gallery-grid\\"><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image10.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image11.png\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/image12.png\\"/></figure></li></ul></figure>
+<!-- /wp:gallery -->"
+`;
+
+exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles full-width images 1`] = `
+"<!-- wp:image {\\"align\\":\\"full\\"} -->
+<figure class=\\"wp-block-image alignfull\\"><img src=\\"https://static.wixstatic.com/media/image9.png\\" alt=\\"image9 alt text\\"/><figcaption>image9 caption</figcaption></figure>
+<!-- /wp:image -->"
+`;
+
 exports[`Block Mapping serializeWixBlocksToWordPressBlocks handles heading blocks 1`] = `
 "<!-- wp:heading -->
 <h2>This is a h2</h2>

--- a/source/services/wix/extractors/communities-blog-app/test/block-mapping.js
+++ b/source/services/wix/extractors/communities-blog-app/test/block-mapping.js
@@ -44,6 +44,10 @@ const testData = {
 			type: 'wix-draft-plugin-video',
 			data: {
 				isCustomVideo: true,
+				config: {
+					size: 'fullWidth',
+					alignment: 'center',
+				},
 				src: {
 					pathname: 'video1.mp4',
 					thumbnail: {

--- a/source/services/wix/extractors/communities-blog-app/test/block-mapping.js
+++ b/source/services/wix/extractors/communities-blog-app/test/block-mapping.js
@@ -82,6 +82,39 @@ const testData = {
 				},
 			},
 		},
+		5: {
+			type: 'wix-draft-plugin-image',
+			data: {
+				src: {
+					file_name: 'image9.png',
+				},
+				config: {
+					size: 'fullWidth',
+					alignment: 'center',
+				},
+				metadata: {
+					alt: 'image9 alt text',
+					caption: 'image9 caption',
+				},
+			},
+		},
+		6: {
+			type: 'wix-draft-plugin-gallery',
+			data: {
+				config: {
+					size: 'fullWidth',
+					alignment: 'center',
+				},
+				items: [
+					{ url: 'image10.png' },
+					{ url: 'image11.png' },
+					{ url: 'image12.png' },
+				],
+				styles: {
+					numberOfImagesPerRow: 2,
+				},
+			},
+		},
 	},
 };
 
@@ -349,6 +382,28 @@ describe( 'Block Mapping', () => {
 		).toMatchSnapshot();
 	} );
 
+	test( 'serializeWixBlocksToWordPressBlocks handles full-width images', () => {
+		const blocks = [
+			{
+				type: 'atomic',
+				text: '',
+				inlineStyleRanges: [],
+				entityRanges: [
+					{
+						offset: 0,
+						length: 0,
+						key: 5,
+					},
+				],
+				data: {},
+			},
+		];
+
+		expect(
+			serializeWixBlocksToWordPressBlocks( blocks, testData )
+		).toMatchSnapshot();
+	} );
+
 	test( 'serializeWixBlocksToWordPressBlocks handles uploaded videos', () => {
 		const blocks = [
 			{
@@ -404,6 +459,28 @@ describe( 'Block Mapping', () => {
 						offset: 0,
 						length: 0,
 						key: 4,
+					},
+				],
+				data: {},
+			},
+		];
+
+		expect(
+			serializeWixBlocksToWordPressBlocks( blocks, testData )
+		).toMatchSnapshot();
+	} );
+
+	test( 'serializeWixBlocksToWordPressBlocks handles full-width image galleries', () => {
+		const blocks = [
+			{
+				type: 'atomic',
+				text: '',
+				inlineStyleRanges: [],
+				entityRanges: [
+					{
+						offset: 0,
+						length: 0,
+						key: 6,
 					},
 				],
 				data: {},

--- a/source/services/wix/extractors/communities-blog-app/test/block-mapping.js
+++ b/source/services/wix/extractors/communities-blog-app/test/block-mapping.js
@@ -91,9 +91,9 @@ describe( 'Block Mapping', () => {
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks returns an empty string when passed no blocks', () => {
-		expect( serializeWixBlocksToWordPressBlocks( [], testData ) ).toEqual(
-			''
-		);
+		expect(
+			serializeWixBlocksToWordPressBlocks( [], testData )
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles "unstyled" blocks as paragraphs', () => {
@@ -114,17 +114,9 @@ describe( 'Block Mapping', () => {
 			},
 		];
 
-		const expected = `<!-- wp:paragraph -->
-<p>This is a paragraph</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>This is another paragraph</p>
-<!-- /wp:paragraph -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles heading blocks', () => {
@@ -145,17 +137,9 @@ describe( 'Block Mapping', () => {
 			},
 		];
 
-		const expected = `<!-- wp:heading -->
-<h2>This is a h2</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading {"level":3} -->
-<h3>This is a h3</h3>
-<!-- /wp:heading -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles code blocks', () => {
@@ -170,15 +154,9 @@ describe( 'Block Mapping', () => {
 			},
 		];
 
-		const expected = `<!-- wp:code -->
-<pre class="wp-block-code"><code>This is some code
-It's possibly the best code I've ever written
-maybe.</code></pre>
-<!-- /wp:code -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles quote blocks', () => {
@@ -192,13 +170,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:quote -->
-<blockquote class="wp-block-quote"><p>Use the source, Luke.</p></blockquote>
-<!-- /wp:quote -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles list items', () => {
@@ -247,21 +221,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:list {"ordered":true} -->
-<ol><li>Number one</li><li>Number two</li><li>Number three</li></ol>
-<!-- /wp:list -->
-
-<!-- wp:list -->
-<ul><li>First</li><li>Second</li></ul>
-<!-- /wp:list -->
-
-<!-- wp:list {"ordered":true} -->
-<ol><li>Number one, second edition</li></ol>
-<!-- /wp:list -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles links in text', () => {
@@ -281,13 +243,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:paragraph -->
-<p>This is <a href="https://wordpress.org/" target="_blank" rel="noreferrer noopener">a link</a>.</p>
-<!-- /wp:paragraph -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles formatting in text', () => {
@@ -332,13 +290,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:paragraph -->
-<p>This is <strong>bold</strong>, <em>italic</em>, <span style="text-decoration: underline;">underlined</span>, <strong><span style="text-decoration: underline;">and</span> <em>a combination</em></strong>.</p>
-<!-- /wp:paragraph -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks ignores underline formatting that matches a link', () => {
@@ -364,13 +318,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:paragraph -->
-<p>This is <a href="https://wordpress.org/" target="_blank" rel="noreferrer noopener">a link</a>.</p>
-<!-- /wp:paragraph -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles single images', () => {
@@ -390,13 +340,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:image {"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="https://wordpress.org/" target="_blank" rel="noopener"><img src="https://static.wixstatic.com/media/image1.png" alt="image1 alt text"/></a><figcaption>image1 caption</figcaption></figure></div>
-<!-- /wp:image -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles uploaded videos', () => {
@@ -416,13 +362,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:video -->
-<figure class="wp-block-video"><video controls poster="https://static.wixstatic.com/media/video1_thumb.jpg" src="https://video.wixstatic.com/video1.mp4"></video></figure>
-<!-- /wp:video -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles embedded videos', () => {
@@ -442,15 +384,9 @@ maybe.</code></pre>
 			},
 		];
 
-		const expected = `<!-- wp:embed {"url":"https://www.youtube.com/watch?v=RWf83UX4vKs","align":"right"} -->
-<figure class="wp-block-embed alignright"><div class="wp-block-embed__wrapper">
-https://www.youtube.com/watch?v=RWf83UX4vKs
-</div></figure>
-<!-- /wp:embed -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 
 	test( 'serializeWixBlocksToWordPressBlocks handles image galleries', () => {
@@ -470,12 +406,8 @@ https://www.youtube.com/watch?v=RWf83UX4vKs
 			},
 		];
 
-		const expected = `<!-- wp:gallery {"columns":4} -->
-<figure class="wp-block-gallery columns-4 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://static.wixstatic.com/media/image2.png"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://static.wixstatic.com/media/image3.png"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://static.wixstatic.com/media/image4.png"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://static.wixstatic.com/media/image5.png"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://static.wixstatic.com/media/image6.png"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://static.wixstatic.com/media/image7.png"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://static.wixstatic.com/media/image8.png"/></figure></li></ul></figure>
-<!-- /wp:gallery -->`;
-
 		expect(
 			serializeWixBlocksToWordPressBlocks( blocks, testData )
-		).toEqual( expected );
+		).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description

Images, videos, and image galleries in the Wix blog app can be full-width, we need to check the right flag to ensure this is recognised.

## How has this been tested?

Unit tests, confirmed WXR is correct.

## Types of changes

Fixes #21.