### PR TITLE
Refactor and fix the cover block unwrapping of columns

### DIFF
--- a/source/services/wix/extractors/static-pages/data.js
+++ b/source/services/wix/extractors/static-pages/data.js
@@ -1,0 +1,117 @@
+const cheerio = require( 'cheerio' );
+const IdFactory = require( '../../../../utils/idfactory.js' );
+
+const extractConfigData = ( html ) => {
+	const configData = {};
+
+	// The configuration data is embedded in script tags in the HTML.
+	const $ = cheerio.load( html );
+	$( 'script' ).each( ( idx, scriptTag ) => {
+		const currentTag = $( scriptTag );
+
+		if ( currentTag.attr( 'src' ) !== undefined ) {
+			return;
+		}
+
+		const vars = currentTag.html().split( /\s*var\s/ );
+		const metaConfigurationRegExp = /^(siteHeader|editorModel|serviceTopology)\s*=\s*(.*)$/;
+
+		for ( let i = 0; i < vars.length; i++ ) {
+			let match;
+			if ( ( match = metaConfigurationRegExp.exec( vars[ i ] ) ) ) {
+				const metaName = match[ 1 ];
+				const metaConfigRawJSON = match[ 2 ].replace( /[;\s]+$/, '' );
+				configData[ metaName ] = JSON.parse( metaConfigRawJSON );
+			}
+		}
+	} );
+
+	return configData;
+};
+
+const fetchPageJson = ( topology, editorUrl ) => ( page ) => {
+	return window
+		.fetch( topology.replace( '{filename}', page.pageJsonFileName ), {
+			referrer: editorUrl,
+			mode: 'same-origin',
+			headers: {
+				Accept:
+					'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+				'Upgrade-Insecure-Requests': 1,
+			},
+		} )
+		.then( ( result ) => result.json() )
+		.catch( () => {
+			return {
+				data: { document_data: {} },
+				structure: { components: [] },
+			};
+		} )
+		.then( ( json ) => {
+			page.postId = IdFactory.get( page.pageId );
+			page.config = json;
+			return page;
+		} )
+		.catch( () => {
+			return {
+				data: { document_data: {} },
+				structure: { components: [] },
+			};
+		} );
+};
+
+const resolveQueries = ( input, data ) => {
+	// skip resolving for non-objects
+	if ( typeof input !== 'object' ) {
+		return input;
+	}
+
+	// walk over all object keys and resolve known queries
+	Object.entries( input ).forEach( ( entry ) => {
+		const key = entry[ 0 ];
+		const val = entry[ 1 ];
+		let location = 'document_data';
+		switch ( key ) {
+			case 'designQuery':
+			case 'background':
+			case 'mediaRef':
+				location = 'design_data';
+				break;
+		}
+
+		if ( Array.isArray( val ) ) {
+			// Some values can be an array of things that need to get resolved
+			// Example: `input.linkList = [ '#foo', '#baz' ]`
+			input[ key ] = val.map( ( item ) => {
+				if ( ! item || typeof item.valueOf() !== 'string' ) return item;
+				if ( item.substr( 0, 1 ) !== '#' ) return item;
+				const query = item.replace( /^#/, '' );
+				return query
+					? resolveQueries( data[ location ][ query ], data )
+					: item;
+			} );
+		} else if (
+			val &&
+			typeof val.valueOf() === 'string' &&
+			val.substr( 0, 1 ) === '#'
+		) {
+			// Others are just a string
+			// Example: `input.link = '#baz'`
+			const query = val.replace( /^#/, '' );
+			input[ key ] = query
+				? resolveQueries( data[ location ][ query ], data )
+				: val;
+		}
+	} );
+
+	// Components are already objects but we need to deeply resolve their contents
+	if ( input.components ) {
+		input.components = input.components.map( ( subComp ) =>
+			resolveQueries( subComp, data )
+		);
+	}
+
+	return input;
+};
+
+module.exports = { extractConfigData, fetchPageJson, resolveQueries };

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -191,7 +191,8 @@ module.exports = {
 							.filter( Boolean );
 
 						return maybeAddCoverBlock(
-							component, createBlock( 'core/column', {}, innerBlocks )
+							component,
+							createBlock( 'core/column', {}, innerBlocks )
 						);
 					}
 
@@ -206,14 +207,18 @@ module.exports = {
 						if ( innerBlocks.length > 0 ) {
 							let coverBlock = null;
 
-							if ( 'core/cover' === innerBlocks[ 0 ].name && 'core/column' === innerBlocks[0].innerBlocks.name ) {
+							if (
+								'core/cover' === innerBlocks[ 0 ].name &&
+								'core/column' ===
+									innerBlocks[ 0 ].innerBlocks.name
+							) {
 								// The column is has a cover, we need to inject the column here:
 								coverBlock = innerBlocks[ 0 ];
-								innerBlocks = innerBlocks[0].innerBlocks;
+								innerBlocks = innerBlocks[ 0 ].innerBlocks;
 							}
 
 							if ( 1 === innerBlocks.length ) {
-								innerBlocks = innerBlocks[0];
+								innerBlocks = innerBlocks[ 0 ];
 							}
 
 							if ( 'core/column' === innerBlocks.name ) {

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -1,8 +1,13 @@
-const cheerio = require( 'cheerio' );
 const { v4: uuidv4 } = require( 'uuid' );
 const { createBlock, pasteHandler, serialize } = require( '@wordpress/blocks' );
 const slug = require( 'slugify' );
 const IdFactory = require( '../../../../utils/idfactory.js' );
+const {
+	extractConfigData,
+	fetchPageJson,
+	resolveQueries,
+} = require( './data.js' );
+const { convertMenu } = require( './menu.js' );
 
 const escHtml = ( text ) =>
 	String( text )
@@ -10,227 +15,6 @@ const escHtml = ( text ) =>
 		.replace( /&/g, '&amp;' )
 		.replace( />/g, '&gt;' )
 		.replace( /</g, '&lt;' );
-
-const extractConfigData = ( html ) => {
-	const configData = {};
-
-	// The configuration data is embedded in script tags in the HTML.
-	const $ = cheerio.load( html );
-	$( 'script' ).each( ( idx, scriptTag ) => {
-		const currentTag = $( scriptTag );
-
-		if ( currentTag.attr( 'src' ) !== undefined ) {
-			return;
-		}
-
-		const vars = currentTag.html().split( /\s*var\s/ );
-		const metaConfigurationRegExp = /^(siteHeader|editorModel|serviceTopology)\s*=\s*(.*)$/;
-
-		for ( let i = 0; i < vars.length; i++ ) {
-			let match;
-			if ( ( match = metaConfigurationRegExp.exec( vars[ i ] ) ) ) {
-				const metaName = match[ 1 ];
-				const metaConfigRawJSON = match[ 2 ].replace( /[;\s]+$/, '' );
-				configData[ metaName ] = JSON.parse( metaConfigRawJSON );
-			}
-		}
-	} );
-
-	return configData;
-};
-
-const handleMenuItemsRecursively = ( menu, items, parent = 0 ) => {
-	const results = [];
-	items.forEach( ( item ) => {
-		const id = IdFactory.get( item.title );
-
-		if ( ! item.type ) {
-			item.type = 'custom';
-			item.object = 'custom';
-			item.objectId = IdFactory.get( item.title );
-		} else if ( 'PageLink' === item.type ) {
-			item.type = 'post_type';
-			item.objectId = IdFactory.get( item.pageId.id );
-			item.status = item.pageId.hidePage ? 'pending' : 'publish';
-			item.object = 'page';
-		}
-
-		results.push( {
-			postId: id,
-			title: item.title || '',
-			date: Date.now(),
-			name: item.title ? slug( item.title, { lower: true } ) : '',
-			type: 'nav_menu_item',
-			parent,
-			status: item.status || 'publish',
-			menuOrder: menu.counter++,
-			meta: {
-				_menu_item_type: item.type,
-				_menu_item_menu_item_parent: String( parent ? parent : '' ),
-				_menu_item_object_id: item.objectId,
-				_menu_item_object: item.object,
-				_menu_item_target: item.target || '',
-				_menu_item_classes: item.classes || '',
-				_menu_item_url: item.url || '',
-				_menu_item_xfn: '',
-			},
-			terms: [ { type: 'nav_menu', ...menu } ],
-		} );
-
-		if ( Array.isArray( item.items ) ) {
-			results.push(
-				...handleMenuItemsRecursively( menu, item.items, id )
-			);
-		}
-	} );
-	return results;
-};
-
-const convertMenu = ( masterPage ) => {
-	const menus = [];
-	const pages = [];
-
-	const menuItem = masterPage.data.document_data.CUSTOM_MAIN_MENU;
-	if ( menuItem ) {
-		menus.push( {
-			role: 'main',
-			...parseMenu( menuItem, masterPage ),
-		} );
-	}
-
-	menus.forEach( ( menu ) => {
-		const term = {
-			id: IdFactory.get( menu.title ),
-			name: menu.title,
-			slug: slug( `${ menu.title }-1`, { lower: true } ),
-			counter: 0,
-			meta: {
-				menu_role: menu.role || null,
-				parsing_session_id: 1,
-			},
-		};
-
-		pages.push( ...handleMenuItemsRecursively( term, menu.items ) );
-	} );
-
-	return pages;
-};
-
-const parseMenu = ( menuItem, masterPage ) => {
-	menuItem = resolveQueries( menuItem, masterPage.data );
-	let menu = {
-		title: menuItem.name || menuItem.label,
-	};
-
-	if ( menuItem.link ) {
-		const parsedLink = menuItem.link;
-		menu = {
-			...parsedLink,
-			...menu,
-		};
-
-		if ( parsedLink.attachment ) {
-			// handleAttachment( parsedLink.attachment );
-		}
-
-		if ( parsedLink.target !== '_blank' ) {
-			delete menu.target;
-		}
-	}
-
-	if ( menuItem.items && menuItem.items.length > 0 ) {
-		menu.items = menuItem.items.map( ( menuData ) =>
-			parseMenu( menuData, masterPage )
-		);
-	}
-
-	return menu;
-};
-
-const resolveQueries = ( input, data ) => {
-	// skip resolving for non-objects
-	if ( typeof input !== 'object' ) {
-		return input;
-	}
-
-	// walk over all object keys and resolve known queries
-	Object.entries( input ).forEach( ( entry ) => {
-		const key = entry[ 0 ];
-		const val = entry[ 1 ];
-		let location = 'document_data';
-		switch ( key ) {
-			case 'designQuery':
-			case 'background':
-			case 'mediaRef':
-				location = 'design_data';
-				break;
-		}
-
-		if ( Array.isArray( val ) ) {
-			// Some values can be an array of things that need to get resolved
-			// Example: `input.linkList = [ '#foo', '#baz' ]`
-			input[ key ] = val.map( ( item ) => {
-				if ( ! item || typeof item.valueOf() !== 'string' ) return item;
-				if ( item.substr( 0, 1 ) !== '#' ) return item;
-				const query = item.replace( /^#/, '' );
-				return query
-					? resolveQueries( data[ location ][ query ], data )
-					: item;
-			} );
-		} else if (
-			val &&
-			typeof val.valueOf() === 'string' &&
-			val.substr( 0, 1 ) === '#'
-		) {
-			// Others are just a string
-			// Example: `input.link = '#baz'`
-			const query = val.replace( /^#/, '' );
-			input[ key ] = query
-				? resolveQueries( data[ location ][ query ], data )
-				: val;
-		}
-	} );
-
-	// Components are already objects but we need to deeply resolve their contents
-	if ( input.components ) {
-		input.components = input.components.map( ( subComp ) =>
-			resolveQueries( subComp, data )
-		);
-	}
-
-	return input;
-};
-
-const fetchPageJson = ( topology, editorUrl ) => ( page ) => {
-	return window
-		.fetch( topology.replace( '{filename}', page.pageJsonFileName ), {
-			referrer: editorUrl,
-			mode: 'same-origin',
-			headers: {
-				Accept:
-					'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-				'Upgrade-Insecure-Requests': 1,
-			},
-		} )
-		.then( ( result ) => result.json() )
-		.catch( () => {
-			return {
-				data: { document_data: {} },
-				structure: { components: [] },
-			};
-		} )
-		.then( ( json ) => {
-			page.postId = IdFactory.get( page.pageId );
-			page.config = json;
-			return page;
-		} )
-		.catch( () => {
-			return {
-				data: { document_data: {} },
-				structure: { components: [] },
-			};
-		} );
-};
 
 module.exports = {
 	/**
@@ -406,7 +190,9 @@ module.exports = {
 							.flat()
 							.filter( Boolean );
 
-						return createBlock( 'core/column', {}, innerBlocks );
+						return maybeAddCoverBlock(
+							component, createBlock( 'core/column', {}, innerBlocks )
+						);
 					}
 
 					if (
@@ -417,24 +203,46 @@ module.exports = {
 							parseComponent
 						);
 
-						if (
-							innerBlocks.length > 0 &&
-							'core/column' === innerBlocks[ 0 ].name
-						) {
-							if ( innerBlocks.length > 1 ) {
-								// Real columns == more than 1, we need to wrap it with a columns block.
-								return maybeAddCoverBlock(
-									component,
-									createBlock(
-										'core/columns',
-										{},
-										innerBlocks
-									)
-								);
+						if ( innerBlocks.length > 0 ) {
+							let coverBlock = null;
+
+							if ( 'core/cover' === innerBlocks[ 0 ].name && 'core/column' === innerBlocks[0].innerBlocks.name ) {
+								// The column is has a cover, we need to inject the column here:
+								coverBlock = innerBlocks[ 0 ];
+								innerBlocks = innerBlocks[0].innerBlocks;
 							}
 
-							// Just a single column, let's unwrap it.
-							innerBlocks = innerBlocks[ 0 ].innerBlocks;
+							if ( 1 === innerBlocks.length ) {
+								innerBlocks = innerBlocks[0];
+							}
+
+							if ( 'core/column' === innerBlocks.name ) {
+								// Just a single column, let's unwrap it.
+								innerBlocks = innerBlocks.innerBlocks;
+
+								if ( null !== coverBlock ) {
+									coverBlock.innerBlocks = innerBlocks;
+									return coverBlock;
+								}
+
+								return innerBlocks;
+							}
+
+							if ( innerBlocks.length > 1 ) {
+								// Real columns == more than 1, we need to wrap it with a columns block.
+								const columnsBlock = createBlock(
+									'core/columns',
+									{},
+									innerBlocks
+								);
+
+								if ( null !== coverBlock ) {
+									coverBlock.innerBlocks = [ columnsBlock ];
+									return coverBlock;
+								}
+
+								return columnsBlock;
+							}
 						}
 					} else {
 						innerBlocks = component.components

--- a/source/services/wix/extractors/static-pages/menu.js
+++ b/source/services/wix/extractors/static-pages/menu.js
@@ -1,0 +1,113 @@
+const IdFactory = require( '../../../../utils/idfactory.js' );
+const { resolveQueries } = require( './data.js' );
+const slug = require( 'slugify' );
+
+const handleMenuItemsRecursively = ( menu, items, parent = 0 ) => {
+	const results = [];
+	items.forEach( ( item ) => {
+		const id = IdFactory.get( item.title );
+
+		if ( ! item.type ) {
+			item.type = 'custom';
+			item.object = 'custom';
+			item.objectId = IdFactory.get( item.title );
+		} else if ( 'PageLink' === item.type ) {
+			item.type = 'post_type';
+			item.objectId = IdFactory.get( item.pageId.id );
+			item.status = item.pageId.hidePage ? 'pending' : 'publish';
+			item.object = 'page';
+		}
+
+		results.push( {
+			postId: id,
+			title: item.title || '',
+			date: Date.now(),
+			name: item.title ? slug( item.title, { lower: true } ) : '',
+			type: 'nav_menu_item',
+			parent,
+			status: item.status || 'publish',
+			menuOrder: menu.counter++,
+			meta: {
+				_menu_item_type: item.type,
+				_menu_item_menu_item_parent: String( parent ? parent : '' ),
+				_menu_item_object_id: item.objectId,
+				_menu_item_object: item.object,
+				_menu_item_target: item.target || '',
+				_menu_item_classes: item.classes || '',
+				_menu_item_url: item.url || '',
+				_menu_item_xfn: '',
+			},
+			terms: [ { type: 'nav_menu', ...menu } ],
+		} );
+
+		if ( Array.isArray( item.items ) ) {
+			results.push(
+				...handleMenuItemsRecursively( menu, item.items, id )
+			);
+		}
+	} );
+	return results;
+};
+
+const convertMenu = ( masterPage ) => {
+	const menus = [];
+	const pages = [];
+
+	const menuItem = masterPage.data.document_data.CUSTOM_MAIN_MENU;
+	if ( menuItem ) {
+		menus.push( {
+			role: 'main',
+			...parseMenu( menuItem, masterPage ),
+		} );
+	}
+
+	menus.forEach( ( menu ) => {
+		const term = {
+			id: IdFactory.get( menu.title ),
+			name: menu.title,
+			slug: slug( `${ menu.title }-1`, { lower: true } ),
+			counter: 0,
+			meta: {
+				menu_role: menu.role || null,
+				parsing_session_id: 1,
+			},
+		};
+
+		pages.push( ...handleMenuItemsRecursively( term, menu.items ) );
+	} );
+
+	return pages;
+};
+
+const parseMenu = ( menuItem, masterPage ) => {
+	menuItem = resolveQueries( menuItem, masterPage.data );
+	let menu = {
+		title: menuItem.name || menuItem.label,
+	};
+
+	if ( menuItem.link ) {
+		const parsedLink = menuItem.link;
+		menu = {
+			...parsedLink,
+			...menu,
+		};
+
+		if ( parsedLink.attachment ) {
+			// handleAttachment( parsedLink.attachment );
+		}
+
+		if ( parsedLink.target !== '_blank' ) {
+			delete menu.target;
+		}
+	}
+
+	if ( menuItem.items && menuItem.items.length > 0 ) {
+		menu.items = menuItem.items.map( ( menuData ) =>
+			parseMenu( menuData, masterPage )
+		);
+	}
+
+	return menu;
+};
+
+module.exports = { handleMenuItemsRecursively, convertMenu, parseMenu };


### PR DESCRIPTION
## Description
PR #40 was supposed to introduce the cover block but broke it in the attempts to properly convert Wix columns. This brings back cover support.

There are multiple factors that make a conversion to Gutenberg blocks not 100% straight forward:
1. In the Wix editor content is often horizontally segmented in to "strips" which contain only a single column. We don't want this to be converted to a single Gutenberg column. So after we converted the column and then encounter it was just one, we strip the `core/column` away again
2. Background images are attached to the single column and not to the strip. So when recursively converting the columns, we first create the `core/column` block and if it has a background, wrap it in a `core/cover` block, knowing that this can't remain. In the outer recursion, we need to first unwrap the cover block and either remove the column block if it's just a single column, or add the `core/columns` block between the `core/cover` block and `core/column`.

Wix
```
strip
 - column (with background)
   - paragraph
```
Conversion midway
```
strip
 - core/cover
   - core/column
     - core/paragraph
```
Converted
```
core/cover
 - core/paragraph
```

---

Wix
```
strip
 - column (no background)
   - paragraph
```
Conversion midway
```
strip
   - core/column
     - core/paragraph
```
Converted
```
 - core/paragraph
```

---

Wix
```
strip (with background)
 - column
   - paragraph
 - column
   - paragraph
```
Conversion midway
```
strip
 - core/columns
   - core/column
     - core/paragraph
   - core/column
     - core/paragraph
```

Converted
```
core/cover
 - core/columns
   - core/column
     - core/paragraph
   - core/column
     - core/paragraph
```

## Types of changes
Janitorial (Refactoring) / Bug fix