### PR TITLE
Store provided object ids in the WXR

### DIFF
--- a/packages/site-parsers/src/parsers/wix/containers/form.js
+++ b/packages/site-parsers/src/parsers/wix/containers/form.js
@@ -24,9 +24,7 @@ module.exports = {
 						format: 'date',
 						label: component.dataQuery.label,
 						placeholder: component.dataQuery.placeholder,
-						required: component.propertyQuery.required
-							? 'true'
-							: 'false',
+						required: !! component.propertyQuery.required,
 						dateFormat: component.propertyQuery.dateFormat,
 						disabledDates: component.dataQuery.disabledDates,
 						disabledDaysOfWeek:
@@ -37,18 +35,14 @@ module.exports = {
 						type: 'textarea',
 						label: component.dataQuery.label,
 						placeholder: component.dataQuery.placeholder,
-						required: component.propertyQuery.required
-							? 'true'
-							: 'false',
+						required: !! component.propertyQuery.required,
 					};
 				case 'TextInput':
 					return {
 						type: 'text',
 						label: component.dataQuery.label,
 						placeholder: component.dataQuery.placeholder,
-						required: component.propertyQuery.required
-							? 'true'
-							: 'false',
+						required: !! component.propertyQuery.required,
 					};
 				case 'SelectableList':
 					return {
@@ -63,9 +57,7 @@ module.exports = {
 								};
 							}
 						),
-						required: component.propertyQuery.required
-							? 'true'
-							: 'false',
+						required: !! component.propertyQuery.required,
 					};
 				case 'LinkableButton':
 					return {

--- a/packages/site-parsers/src/parsers/wix/data.js
+++ b/packages/site-parsers/src/parsers/wix/data.js
@@ -111,6 +111,7 @@ const addMediaAttachment = ( data, mediaUrl, component ) => {
 const addObject = ( data, objType, objData ) => {
 	const id = 1 + data.objects.length;
 	data.objects.push( {
+		id,
 		type: objType,
 		data: objData,
 	} );

--- a/packages/wxr/src/1.3/schema.js
+++ b/packages/wxr/src/1.3/schema.js
@@ -404,5 +404,18 @@ module.exports = {
 			},
 		],
 	},
-	objects: {},
+	objects: {
+		fields: [
+			{
+				name: 'id',
+				type: 'int',
+				element: 'wp:object_id',
+			},
+			{
+				name: 'type',
+				type: 'string',
+				element: 'wp:object_type',
+			},
+		],
+	},
 };

--- a/source/services/wix/extractors/static-pages/index.js
+++ b/source/services/wix/extractors/static-pages/index.js
@@ -103,7 +103,7 @@ module.exports = {
 	 */
 	save: async ( data, wxr ) => {
 		data.objects.forEach( ( obj ) => {
-			wxr.addObject( obj.type, obj.data );
+			wxr.addObject( obj.id, obj.type, obj.data );
 		} );
 		data.pages.forEach( ( post ) => {
 			const terms = post.terms || [];


### PR DESCRIPTION
## Description
In order to match the objects up with the ids, we need to use the id from the id factory in the WXR as well.

## How has this been tested?
Imported the Rockfield demo site

## Types of changes
Bug-fix