### PR TITLE
Introduce Video component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/video.js
+++ b/packages/site-parsers/src/parsers/wix/components/video.js
@@ -1,0 +1,39 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+const getVideoEmbedUrl = ( settings ) => {
+	switch ( settings.videoType ) {
+		case 'YOUTUBE':
+			return `https://www.youtube.com/watch?v=${ settings.videoId }`;
+		case 'VIMEO':
+			return `https://player.vimeo.com/video/${ settings.videoId }`;
+		case 'DAILYMOTION':
+			return `https://www.dailymotion.com/embed/video/${ settings.videoId }`;
+		case 'FACEBOOK':
+			return `https://www.facebook.com/${ settings.videoId }`;
+		default:
+			return '';
+	}
+};
+
+module.exports = {
+	type: 'Video',
+	parseComponent: ( component ) => {
+		const attrs = {
+			src: getVideoEmbedUrl( component.dataQuery ),
+		};
+
+		if (
+			component.propertyQuery &&
+			component.propertyQuery.type === 'VideoProperties'
+		) {
+			Object.assign( attrs, {
+				loop: component.propertyQuery.loop,
+				autoplay: component.propertyQuery.autoplay,
+				controls:
+					component.propertyQuery.showControls !== 'always_hide',
+			} );
+		}
+
+		return createBlock( 'core/video', attrs );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/video.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {


### PR DESCRIPTION
## Description
Changes contain video component mapper support, following the same logic as it is on the site-parser side.
Basically, it very similar without special differences.

site-parser logic:
- https://github.com/Automattic/site-parser/blob/master/src/importers/wix/apps/static-pages/components/wysiwyg.viewer.components.Video.js
- https://github.com/Automattic/site-parser/blob/6ce4af066744d62ec7e684b7c4749dc2fee00b62/src/importers/wix/utils/video-embeds.js#L14

## How has this been tested?
It has passed manual testing:
- create a private website
- create a page with the `Video Player` component
- run the parser
- result should be a proper Gutenberg block `core/video`

## Types of changes
New feature (non-breaking change which adds functionality)
