### PR TITLE
Introduce Audio component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/audio.js
+++ b/packages/site-parsers/src/parsers/wix/components/audio.js
@@ -1,0 +1,34 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+/**
+ * MusicPlayerData covers:
+ * - Wix music
+ * - Audio player
+ */
+module.exports = {
+	type: 'MusicPlayerData',
+	parseComponent: ( component, { metaData } ) => {
+		if ( ! component.dataQuery.uri ) {
+			return;
+		}
+
+		const uri = component.dataQuery.uri;
+		const prefix = metaData.serviceTopology.staticAudioUrl;
+
+		const attrs = {
+			src: prefix + '/' + uri,
+		};
+
+		if (
+			component.propertyQuery &&
+			component.propertyQuery.type === 'MusicPlayerProperties'
+		) {
+			Object.assign( attrs, {
+				loop: component.propertyQuery.autoplay,
+				autoplay: component.propertyQuery.autoplay,
+			} );
+		}
+
+		return createBlock( 'core/audio', attrs );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/audio.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {


### PR DESCRIPTION
## Description
Changes contain audio component mapper support, following the same logic as it is on the site-parser side.
Basically, it very similar without special differences.

site-parser logic:
- https://github.com/Automattic/site-parser/blob/6ce4af066744d62ec7e684b7c4749dc2fee00b62/src/importers/wix/apps/static-pages/components/wysiwyg.viewer.components.AudioPlayer.js
- https://github.com/Automattic/site-parser/blob/6ce4af066744d62ec7e684b7c4749dc2fee00b62/src/importers/wix/utils/audio.js#L6

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Audio Player` component
- run the parser
- result should be a proper Gutenberg block `core/audio`

## Types of changes
New feature (non-breaking change which adds functionality)
