### PR TITLE
Introduce TwitterFollowButton component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/twitter-follow.js
+++ b/packages/site-parsers/src/parsers/wix/components/twitter-follow.js
@@ -1,0 +1,14 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	type: 'TwitterFollow',
+
+	parseComponent: ( component ) => {
+		return createBlock( 'core/social-links', { openInNewTab: true }, [
+			createBlock( 'core/social-link', {
+				url: `//twitter.com/${ component.dataQuery.accountToFollow }`,
+				service: 'twitter',
+			} ),
+		] );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/twitter-follow.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {


### PR DESCRIPTION
## Description
Changes contain **Twitter Follow Button** component mapper support.
Gutenberg blocks have support for Twitter, but there is a missing option for the official follow button. We decided to show a simple Twitter social icon with the proper profile URL so that the end-user can hit the follow button on Twitter's page.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Twitter Follow` component
- run the parser
- result should be a proper Gutenberg block `core/social-links` with inner `core/social-link`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
