### PR TITLE
Introduce Spotify component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/sound-cloud.js
+++ b/packages/site-parsers/src/parsers/wix/components/sound-cloud.js
@@ -1,0 +1,18 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	parseComponent: ( component, { getThemeDataRef } ) => {
+		const themeData = getThemeDataRef( component.styleId );
+
+		if (
+			themeData &&
+			themeData.style &&
+			themeData.style.properties &&
+			themeData.style.properties.param_font_resolveUrl
+		) {
+			return createBlock( 'core/embed', {
+				url: themeData.style.properties.param_font_resolveUrl,
+			} );
+		}
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/components/spotify.js
+++ b/packages/site-parsers/src/parsers/wix/components/spotify.js
@@ -1,0 +1,15 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	parseComponent: ( component ) => {
+		const tpaData = component.dataQuery.tpaData;
+
+		if ( typeof tpaData === 'object' && tpaData !== null ) {
+			const content = JSON.parse( tpaData.content );
+
+			return createBlock( 'core/embed', {
+				url: content.spotifyURI,
+			} );
+		}
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/components/tpa-widget.js
+++ b/packages/site-parsers/src/parsers/wix/components/tpa-widget.js
@@ -1,4 +1,5 @@
 const { parseComponent: parseSpotify } = require( './spotify' );
+const { parseComponent: parseSoundCloud } = require( './sound-cloud' );
 
 const APP_ID = {
 	SPOTIFY: '2575',
@@ -8,12 +9,14 @@ const APP_ID = {
 
 module.exports = {
 	type: 'TPAWidget',
-	parseComponent: ( component ) => {
+	// eslint-disable-next-line
+	parseComponent: function ( component ) {
 		switch ( component.dataQuery.applicationId ) {
 			case APP_ID.SPOTIFY:
-				return parseSpotify( component );
-			case APP_ID.WIX_MUSIC:
+				return parseSpotify( ...arguments );
 			case APP_ID.SOUND_CLOUD:
+				return parseSoundCloud( ...arguments );
+			case APP_ID.WIX_MUSIC:
 			default:
 				break;
 		}

--- a/packages/site-parsers/src/parsers/wix/components/tpa-widget.js
+++ b/packages/site-parsers/src/parsers/wix/components/tpa-widget.js
@@ -1,0 +1,21 @@
+const { parseComponent: parseSpotify } = require( './spotify' );
+
+const APP_ID = {
+	SPOTIFY: '2575',
+	WIX_MUSIC: '1662',
+	SOUND_CLOUD: '3195',
+};
+
+module.exports = {
+	type: 'TPAWidget',
+	parseComponent: ( component ) => {
+		switch ( component.dataQuery.applicationId ) {
+			case APP_ID.SPOTIFY:
+				return parseSpotify( component );
+			case APP_ID.WIX_MUSIC:
+			case APP_ID.SOUND_CLOUD:
+			default:
+				break;
+		}
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/data.js
+++ b/packages/site-parsers/src/parsers/wix/data.js
@@ -117,8 +117,19 @@ const addObject = ( data, objType, objData ) => {
 	return id;
 };
 
+const getThemeDataRef = ( page, id ) => {
+	return (
+		page &&
+		page.config &&
+		page.config.data &&
+		page.config.data.theme_data &&
+		page.config.data.theme_data[ id ]
+	);
+};
+
 module.exports = {
 	resolveQueries,
 	addMediaAttachment,
 	addObject,
+	getThemeDataRef,
 };

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/tpa-widget.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {

--- a/packages/site-parsers/src/parsers/wix/pages.js
+++ b/packages/site-parsers/src/parsers/wix/pages.js
@@ -9,7 +9,12 @@ const { serialize } = require( '@wordpress/blocks' );
 const { IdFactory } = require( '../../utils' );
 const { maybeAddCoverBlock } = require( './containers/cover.js' );
 const { containerMapper, componentMapper } = require( './mappers.js' );
-const { resolveQueries, addMediaAttachment, addObject } = require( './data' );
+const {
+	resolveQueries,
+	addMediaAttachment,
+	addObject,
+	getThemeDataRef,
+} = require( './data' );
 
 const addHeaderPage = ( data, masterPage ) => {
 	data.pages.push( {
@@ -83,6 +88,7 @@ const parsePages = ( data, metaData, masterPage ) => {
 				data,
 				metaData.serviceTopology.staticMediaUrl
 			),
+			getThemeDataRef: getThemeDataRef.bind( null, page ),
 		};
 
 		const recursiveComponentParser = ( component ) => {


### PR DESCRIPTION
## Description
Changes contain Spotify component mapper support.

Since the component type is `TPAWidget`, we added additional logic to match a proper widget with widget id.
There are additional hooks for future mappers such as SoundCloud and WixMusic.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Spotify` component
- run the parser
- result should be a proper Gutenberg block `core/embed`

## Types of changes
New feature (non-breaking change which adds functionality)
