### PR TITLE
Introduce Anchor component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/anchor.js
+++ b/packages/site-parsers/src/parsers/wix/components/anchor.js
@@ -1,0 +1,14 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	type: 'Anchor',
+	parseComponent: ( component ) => {
+		const dataQuery = component.dataQuery;
+
+		if ( dataQuery && dataQuery.type === 'Anchor' && dataQuery.name ) {
+			return createBlock( 'core/paragraph', {
+				id: dataQuery.name,
+			} );
+		}
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/anchor.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {


### PR DESCRIPTION
## Description
Changes contain `Anchor component` mapper support.

On the site-parser side, it's a simple `<a>` tag with the provided ID. Instead of the `<a>` tag, this mapper provides paragraph `<p>` with an assigned ID.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Anchor` component
- run the parser
- result should be a proper Gutenberg block `core/paragraph`

## Types of changes
New feature (non-breaking change which adds functionality)
