### PR TITLE
Introduce ImageList (gallery) component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/image-list.js
+++ b/packages/site-parsers/src/parsers/wix/components/image-list.js
@@ -1,0 +1,51 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+const parseImages = ( images, metaData ) => {
+	return images.map( ( img ) => {
+		const prefix = metaData.serviceTopology.staticAudioUrl;
+
+		const attrs = {
+			id: img.id,
+			alt: img.alt,
+			title: img.title,
+			caption: img.description,
+			url: prefix + '/' + img.uri,
+			fulUrl: '/' + prefix + '/' + img.uri,
+		};
+
+		if ( img.link ) {
+			attrs.link = img.link.url;
+		}
+
+		return attrs;
+	} );
+};
+
+module.exports = {
+	type: 'ImageList',
+	parseComponent: ( component, { metaData } ) => {
+		const images = parseImages( component.dataQuery.items, metaData );
+		const attrs = {
+			images,
+			ids: images.map( ( img ) => img.id ),
+		};
+
+		switch ( component.propertyQuery.type ) {
+			// Gallery: 3DCarousel, 3DCarousel, Slider Galleries
+			case 'FreestyleProperties':
+			case 'SlideShowGalleryProperties':
+				return createBlock( 'core/gallery', attrs );
+
+			// Gallery: Grid
+			case 'MasonryProperties':
+			case 'HoneycombProperties':
+			case 'MatrixGalleryProperties':
+			case 'PaginatedGridGalleryProperties':
+				attrs.columns = component.propertyQuery.numCols || 3;
+				return createBlock( 'core/gallery', attrs );
+
+			// Gallery: Currently unsupported
+			case 'ImpressProperties':
+		}
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -14,6 +14,7 @@ const containerHandlers = [
 const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
+	require( './components/image-list.js' ),
 	require( './components/button.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 


### PR DESCRIPTION
## Description
Changes contain `Gallery component` mapper support.

✅ The list of supported galleries:
- 3DCarousel
- Slider
- Masonry
- Paginated
- Honeycomb
- Matrix
- Paginated grid

❌ Non-supported galleries:
- ImpressProperties

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with `Gallery component` from the list above
- run the parser
- result should be a proper Gutenberg block `core/gallery`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
