### PR TITLE
Introduce Separator component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/separator.js
+++ b/packages/site-parsers/src/parsers/wix/components/separator.js
@@ -1,0 +1,8 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	type: 'FiveGridLine',
+	parseComponent: () => {
+		createBlock( 'core/separator' );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/separator.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -24,6 +24,16 @@ const wrapResult = ( block, component ) => {
 	return block;
 };
 
+/**
+ * @param {string} componentType (ex. wysiwyg.viewer.components.FiveGridLine)
+ * @return {string} (ex. FiveGridLine)
+ */
+const getTypeFromComponentPath = ( componentType ) => {
+	const type = componentType.split( '.' );
+
+	return type[ type.length - 1 ];
+};
+
 module.exports = {
 	containerMapper: (
 		component,
@@ -52,22 +62,21 @@ module.exports = {
 	},
 
 	componentMapper: ( component, meta ) => {
-		if ( ! component.dataQuery ) {
-			return null;
-		}
+		const type =
+			( component.dataQuery && component.dataQuery.type ) ||
+			getTypeFromComponentPath( component.componentType );
 
-		if ( component.dataQuery.type in componentHandlers ) {
+		if ( type in componentHandlers ) {
 			return wrapResult(
-				componentHandlers[ component.dataQuery.type ].parseComponent(
-					component,
-					meta
-				),
+				componentHandlers[ type ].parseComponent( component, meta ),
 				component
 			);
 		}
 
-		if ( component.dataQuery.text ) {
+		if ( component.dataQuery && component.dataQuery.text ) {
 			return pasteHandler( { HTML: component.dataQuery.text } );
 		}
+
+		return null;
 	},
 };


### PR DESCRIPTION
## Description
Changes contain `Separator component` mapper support.

Basically, it is very similar to the site-parser `FiveGridLine` component`, except for the width size, which is not a supported value from the Gutenberg Separator block.

Also, another change provides the way to get component by `type` or `componentType` (last segment) when the regular type is not available, which is the case with the `FiveGridLine`. To be clear, `FiveGridLine` component doesn't have a `type` field and we manage to get it by providing the last segment from the full componentType `wysiwyg.viewer.components.FiveGridLine`.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with `FiveGridLine` component
- run the parser
- result should be a proper Gutenberg block `core/separator`

## Types of changes
New feature (non-breaking change which adds functionality)
