### PR TITLE
Introduce StylableButton component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/button-stylable.js
+++ b/packages/site-parsers/src/parsers/wix/components/button-stylable.js
@@ -1,0 +1,12 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	type: 'StylableButton',
+	parseComponent: ( component ) => {
+		return createBlock( 'core/button', {
+			url: component.dataQuery.link.url,
+			linkTarget: component.dataQuery.link.target,
+			text: component.dataQuery.label,
+		} );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/button-stylable.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {


### PR DESCRIPTION
## Description
Changes contain `StylableButton` mapper support. It's straightforward mapping with our regular button block.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `StylableButton` component
- run the parser
- result should be a proper Gutenberg block `core/button`

## Types of changes
<!-- New feature (non-breaking change which adds functionality) -->
