### PR TITLE
Introduce LinkBar component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/image-list.js
+++ b/packages/site-parsers/src/parsers/wix/components/image-list.js
@@ -1,4 +1,5 @@
 const { createBlock } = require( '@wordpress/blocks' );
+const { parseComponent: linkBarParseComponent } = require( './link-bar' );
 
 const parseImages = ( images, metaData ) => {
 	return images.map( ( img ) => {
@@ -46,6 +47,10 @@ module.exports = {
 
 			// Gallery: Currently unsupported
 			case 'ImpressProperties':
+				break;
+
+			case 'LinkBarProperties':
+				return linkBarParseComponent( component );
 		}
 	},
 };

--- a/packages/site-parsers/src/parsers/wix/components/image-list.js
+++ b/packages/site-parsers/src/parsers/wix/components/image-list.js
@@ -1,0 +1,51 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+const parseImages = ( images, metaData ) => {
+	return images.map( ( img ) => {
+		const prefix = metaData.serviceTopology.staticAudioUrl;
+
+		const attrs = {
+			id: img.id,
+			alt: img.alt,
+			title: img.title,
+			caption: img.description,
+			url: prefix + '/' + img.uri,
+			fulUrl: '/' + prefix + '/' + img.uri,
+		};
+
+		if ( img.link ) {
+			attrs.link = img.link.url;
+		}
+
+		return attrs;
+	} );
+};
+
+module.exports = {
+	type: 'ImageList',
+	parseComponent: ( component, { metaData } ) => {
+		const images = parseImages( component.dataQuery.items, metaData );
+		const attrs = {
+			images,
+			ids: images.map( ( img ) => img.id ),
+		};
+
+		switch ( component.propertyQuery.type ) {
+			// Gallery: 3DCarousel, 3DCarousel, Slider Galleries
+			case 'FreestyleProperties':
+			case 'SlideShowGalleryProperties':
+				return createBlock( 'core/gallery', attrs );
+
+			// Gallery: Grid
+			case 'MasonryProperties':
+			case 'HoneycombProperties':
+			case 'MatrixGalleryProperties':
+			case 'PaginatedGridGalleryProperties':
+				attrs.columns = component.propertyQuery.numCols || 3;
+				return createBlock( 'core/gallery', attrs );
+
+			// Gallery: Currently unsupported
+			case 'ImpressProperties':
+		}
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/components/link-bar.js
+++ b/packages/site-parsers/src/parsers/wix/components/link-bar.js
@@ -1,0 +1,27 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+const getServiceNameFromUrl = ( url ) => {
+	return new URL( url ).hostname.replace( 'www.', '' ).split( '.' )[ 0 ];
+};
+
+module.exports = {
+	parseComponent: ( component ) => {
+		const socialLinkAttrs = component.dataQuery.items.map( ( item ) => {
+			const url = item.link && item.link.url;
+
+			return {
+				url,
+				label: item.title,
+				service: url && getServiceNameFromUrl( url ),
+			};
+		} );
+
+		return createBlock(
+			'core/social-links',
+			{ openInNewTab: true },
+			socialLinkAttrs.map( ( attrs ) =>
+				createBlock( 'core/social-link', attrs )
+			)
+		);
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -14,6 +14,7 @@ const containerHandlers = [
 const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
+	require( './components/image-list.js' ),
 	require( './components/button.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 

--- a/packages/site-parsers/src/utils/register-blocks.js
+++ b/packages/site-parsers/src/utils/register-blocks.js
@@ -28,6 +28,11 @@ module.exports = {
 				},
 			},
 		} );
-		__experimentalRegisterExperimentalCoreBlocks();
+
+		if (
+			typeof __experimentalRegisterExperimentalCoreBlocks === 'function'
+		) {
+			__experimentalRegisterExperimentalCoreBlocks();
+		}
 	},
 };

--- a/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
+++ b/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
@@ -798,7 +798,17 @@ exports[`wix: rockfield.har 1`] = `
 		<wp:post_id>12</wp:post_id>
 		<title><![CDATA[footer]]></title>
 		<description></description>
-		<content:encoded><![CDATA[<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
+		<content:encoded><![CDATA[<!-- wp:social-links {\\"openInNewTab\\":true} -->
+<ul class=\\"wp-block-social-links\\"><!-- wp:social-link {\\"url\\":\\"https://www.facebook.com/wix\\",\\"service\\":\\"facebook\\",\\"label\\":\\"Facebook\\"} /-->
+
+<!-- wp:social-link {\\"label\\":\\"Instagram\\"} /-->
+
+<!-- wp:social-link {\\"label\\":\\"foursquare-2-xxl\\"} /-->
+
+<!-- wp:social-link {\\"label\\":\\"Yelp\\"} /--></ul>
+<!-- /wp:social-links -->
+
+<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"url\\":\\"/home\\"} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Menu\\",\\"url\\":\\"/menu\\"} -->


### PR DESCRIPTION
## Description
⚠️ Before reviewing the PR, please review [this one](https://github.com/pento/free-as-in-speech/pull/59).

Changes contain `LinkBar` component mapper support.

Simply mapping a list of social icons. It is a straightforward change since Gutenberg has a proper `core/social-icons` block.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Link Bar` component
- run the parser
- result should be a proper Gutenberg block `core/social-links`

## Types of changes
New feature (non-breaking change which adds functionality)
