### PR TITLE
Introduce Mobile container mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/containers/mobile.js
+++ b/packages/site-parsers/src/parsers/wix/containers/mobile.js
@@ -1,0 +1,15 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	componentType: 'mobile.core.components.Container',
+	parseComponent: ( component, recursiveComponentParser ) => {
+		return createBlock(
+			'core/group',
+			{},
+			component.components
+				.map( recursiveComponentParser )
+				.flat()
+				.filter( Boolean )
+		);
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -9,6 +9,7 @@ const containerHandlers = [
 	require( './containers/form.js' ),
 	require( './containers/column.js' ),
 	require( './containers/columns.js' ),
+	require( './containers/mobile.js' ),
 ].reduce( handlerMapper( 'componentType' ), {} );
 
 const componentHandlers = [

--- a/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
+++ b/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
@@ -406,13 +406,15 @@ exports[`wix: rockfield.har 1`] = `
 <p>Click here to make a reservation today!</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading -->
+<!-- wp:group -->
+<div class=\\"wp-block-group\\"><!-- wp:heading -->
 <h2><strong>Published by Joan Smith</strong></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
 <p>My name is Joan Smith. I love discovering new literature.&nbsp;<a>View more posts</a></p>
-<!-- /wp:paragraph -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 
 <!-- wp:paragraph -->
 <p>Previous Post</p>
@@ -670,13 +672,15 @@ exports[`wix: rockfield.har 1`] = `
 <figure class=\\"wp-block-image is-resized\\"><img src=\\"https://static.wixstatic.com/media/7oW5n_JRVYOJnRJpeGHE1bJBAgkY2XaBqeOsl~mv2.jpg\\" alt=\\"appetizer-blurred-background-cheese-2531\\" width=\\"1024\\" height=\\"682\\"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading -->
+<!-- wp:group -->
+<div class=\\"wp-block-group\\"><!-- wp:heading -->
 <h2><strong>Published by Joan Smith</strong></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
 <p>My name is Joan Smith. I love discovering new literature.&nbsp;<a>View more posts</a></p>
-<!-- /wp:paragraph -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 
 <!-- wp:paragraph -->
 <p>Previous Post</p>
@@ -742,13 +746,15 @@ exports[`wix: rockfield.har 1`] = `
 <p>From&nbsp;<a>Wikipedia</a>.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading -->
+<!-- wp:group -->
+<div class=\\"wp-block-group\\"><!-- wp:heading -->
 <h2><strong>Published by Joan Smith</strong></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
 <p>My name is Joan Smith. I love discovering new literature.&nbsp;<a>View more posts</a></p>
-<!-- /wp:paragraph -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 
 <!-- wp:paragraph -->
 <p>Previous Post</p>


### PR DESCRIPTION
## Description
Changes contain `mobile.core.components.Container` mapper support.

It's a simple Gutenberg group container with an inner set of blocks.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Container Box` component
- run the parser
- result should be a proper Gutenberg block `core/group` with inner blocks

## Types of changes
New feature (non-breaking change which adds functionality)
