### PR TITLE
Introduce HTML component mapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "free-as-in-speech",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -17,6 +16,7 @@
 				"@wordpress/i18n": "3.19.2",
 				"@wordpress/rich-text": "3.25.2",
 				"@wordpress/wxr": "file:packages/wxr",
+				"axios": "0.21.1",
 				"cheerio": "1.0.0-rc.6",
 				"dayjs": "1.10.4",
 				"gutenberg-for-node": "file:packages/gutenberg-for-node",
@@ -8014,6 +8014,14 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/axios": {
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+			"dependencies": {
+				"follow-redirects": "^1.10.0"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -14296,6 +14304,25 @@
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+			"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/for-in": {
@@ -38093,6 +38120,14 @@
 			"integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==",
 			"dev": true
 		},
+		"axios": {
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+			"requires": {
+				"follow-redirects": "^1.10.0"
+			}
+		},
 		"axobject-query": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -42738,6 +42773,11 @@
 					}
 				}
 			}
+		},
+		"follow-redirects": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+			"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
 		},
 		"for-in": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"@wordpress/i18n": "3.19.2",
 		"@wordpress/rich-text": "3.25.2",
 		"@wordpress/wxr": "file:packages/wxr",
+		"axios": "0.21.1",
 		"cheerio": "1.0.0-rc.6",
 		"dayjs": "1.10.4",
 		"gutenberg-for-node": "file:packages/gutenberg-for-node",

--- a/packages/site-parsers/package.json
+++ b/packages/site-parsers/package.json
@@ -24,9 +24,9 @@
 	"@wordpress/block-library": "2.29.2",
 	"@wordpress/blocks": "8.0.2",
 	"@wordpress/format-library": "1.27.2",
+	"axios": "0.21.1",
 	"cheerio": "1.0.0-rc.6",
-	"slugify": "1.5.0",
-	"axios": "0.21.1"
+	"slugify": "1.5.0"
   },
   "devDependencies": {
   },

--- a/packages/site-parsers/package.json
+++ b/packages/site-parsers/package.json
@@ -25,7 +25,8 @@
 	"@wordpress/blocks": "8.0.2",
 	"@wordpress/format-library": "1.27.2",
 	"cheerio": "1.0.0-rc.6",
-	"slugify": "1.5.0"
+	"slugify": "1.5.0",
+	"axios": "0.21.1"
   },
   "devDependencies": {
   },

--- a/packages/site-parsers/src/parsers/wix/components/html.js
+++ b/packages/site-parsers/src/parsers/wix/components/html.js
@@ -1,0 +1,20 @@
+const axios = require( 'axios' );
+const { createBlock } = require( '@wordpress/blocks' );
+
+const SUPPORTED_SOURCE = [ 'htmlEmbedded' ];
+
+module.exports = {
+	type: 'HtmlComponent',
+	parseComponent: async ( component, { metaData } ) => {
+		if ( SUPPORTED_SOURCE.indexOf( component.dataQuery.sourceType ) === -1 )
+			return null;
+		const htmlContentUrl =
+			metaData.serviceTopology.staticHTMLComponentUrl +
+			component.dataQuery.url;
+
+		return await axios
+			.get( htmlContentUrl )
+			.then( ( response ) => response.data )
+			.then( ( content ) => createBlock( 'core/html', { content } ) );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/index.js
+++ b/packages/site-parsers/src/parsers/wix/index.js
@@ -4,7 +4,7 @@
 const { addHeaderPage, addFooterPage, parsePages } = require( './pages' );
 const { convertMenu } = require( './menu' );
 
-const staticPagesParser = ( metaData, masterPage, pages = [] ) => {
+const staticPagesParser = async ( metaData, masterPage, pages = [] ) => {
 	const data = {
 		pages,
 		menus: [],
@@ -15,7 +15,7 @@ const staticPagesParser = ( metaData, masterPage, pages = [] ) => {
 	// ↓ methods mutate data object
 	addHeaderPage( data, masterPage );
 	addFooterPage( data, masterPage );
-	parsePages( data, metaData, masterPage );
+	await parsePages( data, metaData, masterPage );
 	convertMenu( data, masterPage );
 
 	return data;

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -13,6 +13,7 @@ const containerHandlers = [
 ].reduce( handlerMapper( 'componentType' ), {} );
 
 const componentHandlers = [
+	require( './components/html.js' ),
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/image-list.js' ),

--- a/packages/site-parsers/src/parsers/wix/pages.js
+++ b/packages/site-parsers/src/parsers/wix/pages.js
@@ -109,12 +109,13 @@ const parsePages = ( data, metaData, masterPage ) => {
 			return componentMapper( component, meta );
 		};
 
-		page.content = page.config.structure.components
-			.map( recursiveComponentParser )
-			.flat()
-			.filter( Boolean )
-			.map( ( wpBlock ) => serialize( wpBlock ) )
-			.join( '\n\n' );
+		Promise.all(
+			page.config.structure.components.map( recursiveComponentParser )
+		)
+			.then( ( x ) => x.flat() )
+			.then( ( x ) => x.filter( Boolean ) )
+			.then( ( x ) => serialize( x ) )
+			.then( ( x ) => ( page.content = x ) );
 	} );
 };
 

--- a/packages/site-parsers/src/parsers/wix/pages.js
+++ b/packages/site-parsers/src/parsers/wix/pages.js
@@ -6,7 +6,7 @@ const { serialize } = require( '@wordpress/blocks' );
 /**
  * Internal dependencies
  */
-const { IdFactory } = require( '../../utils' );
+const { asyncForEach, IdFactory } = require( '../../utils' );
 const { maybeAddCoverBlock } = require( './containers/cover.js' );
 const { containerMapper, componentMapper } = require( './mappers.js' );
 const {
@@ -74,8 +74,8 @@ const addFooterPage = ( data, masterPage ) => {
 	} );
 };
 
-const parsePages = ( data, metaData, masterPage ) => {
-	data.pages.forEach( ( page ) => {
+const parsePages = async ( data, metaData, masterPage ) => {
+	await asyncForEach( data.pages, ( page ) => {
 		const resolver = ( component ) =>
 			resolveQueries( component, page.config.data, masterPage.data );
 		const meta = {

--- a/packages/site-parsers/src/utils/index.js
+++ b/packages/site-parsers/src/utils/index.js
@@ -1,4 +1,11 @@
+const asyncForEach = async ( array, callback ) => {
+	for ( let index = 0; index < array.length; index++ ) {
+		await callback( array[ index ], index, array );
+	}
+};
+
 module.exports = {
+	asyncForEach,
 	IdFactory: require( './idfactory' ),
 	...require( './register-blocks' ),
 };


### PR DESCRIPTION
## Description
Changes contain `HtmlComponent` mapper support.

Regarding mapper, it's a straightforward change mapping the` core/html` block. It's a similar solution as it is on the site-parser side; custom HTML has a dedicated URL, so it has to be fetched. Because of that, the `parsePages` method has updates to support async component mappers.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `HTML` component
- run the parser
- result should be a proper Gutenberg block `core/html`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
