### PR TITLE
Introduce DocumentMedia component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/document-media.js
+++ b/packages/site-parsers/src/parsers/wix/components/document-media.js
@@ -1,0 +1,27 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+/**
+ * The parent component handler is ./image.js
+ * componentType: DocumentMedia
+ */
+module.exports = {
+	parseComponent: ( component, { addMediaAttachment } ) => {
+		if ( ! component.dataQuery.link ) {
+			return null;
+		}
+
+		const attachment = addMediaAttachment( {
+			uri: component.dataQuery.link.docId,
+			name: component.dataQuery.link.name,
+			alt: component.dataQuery.title,
+		} );
+
+		return createBlock( 'core/file', {
+			id: attachment.id,
+			href: attachment.link,
+			fileName: attachment.name,
+			textLinkHref: attachment.title,
+			downloadButtonText: attachment.name,
+		} );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/components/image.js
+++ b/packages/site-parsers/src/parsers/wix/components/image.js
@@ -1,19 +1,31 @@
 const { createBlock } = require( '@wordpress/blocks' );
+const { parseComponent: parseDocumentMedia } = require( './document-media' );
+
+const parseImage = ( component, { addMediaAttachment } ) => {
+	if ( ! component.dataQuery || ! component.dataQuery.uri ) {
+		return null;
+	}
+
+	const attachment = addMediaAttachment( component.dataQuery );
+
+	return createBlock( 'core/image', {
+		url: attachment.guid,
+		alt: component.dataQuery.alt,
+		width: component.dataQuery.width,
+		height: component.dataQuery.height,
+	} );
+};
 
 module.exports = {
 	type: 'Image',
-	parseComponent: ( component, { addMediaAttachment } ) => {
-		if ( ! component.dataQuery || ! component.dataQuery.uri ) {
-			return null;
+	// eslint-disable-next-line
+	parseComponent: function ( component ) {
+		switch ( component.componentType ) {
+			case 'wysiwyg.viewer.components.documentmedia.DocumentMedia':
+				return parseDocumentMedia( ...arguments );
+
+			default:
+				return parseImage( ...arguments );
 		}
-
-		const attachment = addMediaAttachment( component.dataQuery );
-
-		return createBlock( 'core/image', {
-			url: attachment.guid,
-			alt: component.dataQuery.alt,
-			width: component.dataQuery.width,
-			height: component.dataQuery.height,
-		} );
 	},
 };


### PR DESCRIPTION
## Description
Changes contain `DocumentMedia` mapper support.

Since the document media is a simple button with a proper download link to the media file, it recognizes media attachment and maps it with Gutenberg's `core/file` block.

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Document button` component pointing media file
- run the parser
- result should be a proper Gutenberg block `core/file` with assigned attachment

## Types of changes
New feature (non-breaking change which adds functionality)
