### PR TITLE
Introduce GoogleMap component mapper

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/google-map.js
+++ b/packages/site-parsers/src/parsers/wix/components/google-map.js
@@ -1,0 +1,32 @@
+const { createBlock } = require( '@wordpress/blocks' );
+
+module.exports = {
+	type: 'GeoMap',
+	parseComponent: ( component, { addObject } ) => {
+		return createBlock( 'core-import/plugin-placeholder', {
+			id: addObject( 'map', {
+				height: component.layout.height, // int (px)
+				width: component.layout.width, // int (px)
+
+				zoom: component.propertyQuery.zoom, // int
+				showZoom: component.propertyQuery.showZoom, // boolean
+				showPosition: component.propertyQuery.showPosition, // boolean
+				showStreetView: component.propertyQuery.showStreetView, // boolean
+				showDirectionsLink: component.propertyQuery.showDirectionsLink, // boolean
+				mapDragging: component.propertyQuery.mapDragging, // boolean
+				mapType: component.propertyQuery.mapType, // enum: ROADMAP | SATELLITE | TERRAIN
+				showMapType: component.propertyQuery.showMapType, // boolean
+
+				locations: component.dataQuery.locations.map( ( item ) => ( {
+					latitude: item.latitude,
+					longitude: item.longitude,
+					address: item.address,
+				} ) ),
+
+				pinColor:
+					component.dataQuery.locations[ 0 ] &&
+					component.dataQuery.locations[ 0 ].pinColor,
+			} ),
+		} );
+	},
+};

--- a/packages/site-parsers/src/parsers/wix/data.js
+++ b/packages/site-parsers/src/parsers/wix/data.js
@@ -8,6 +8,24 @@ const slug = require( 'slugify' );
  */
 const { IdFactory } = require( '../../utils' );
 
+const getProperTreeLocation = ( fieldName ) => {
+	switch ( fieldName ) {
+		case 'designQuery':
+		case 'background':
+		case 'mediaRef':
+			return 'design_data';
+
+		case 'propertyQuery':
+			return 'component_properties';
+
+		case 'connectionQuery':
+			return 'connections_data';
+
+		default:
+			return 'document_data';
+	}
+};
+
 const resolveQueries = ( input, data, masterPage ) => {
 	// skip resolving for non-objects
 	if ( typeof input !== 'object' ) {
@@ -18,20 +36,7 @@ const resolveQueries = ( input, data, masterPage ) => {
 	Object.entries( input ).forEach( ( entry ) => {
 		const key = entry[ 0 ];
 		const val = entry[ 1 ];
-		let location = 'document_data';
-		switch ( key ) {
-			case 'designQuery':
-			case 'background':
-			case 'mediaRef':
-				location = 'design_data';
-				break;
-			case 'propertyQuery':
-				location = 'component_properties';
-				break;
-			case 'connectionQuery':
-				location = 'connections_data';
-				break;
-		}
+		const location = getProperTreeLocation( key );
 
 		const mapItems = ( item ) => {
 			if ( ! item || typeof item.valueOf() !== 'string' ) return item;

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -15,6 +15,7 @@ const componentHandlers = [
 	require( './components/menu.js' ),
 	require( './components/image.js' ),
 	require( './components/button.js' ),
+	require( './components/google-map.js' ),
 ].reduce( handlerMapper( 'type' ), {} );
 
 const wrapResult = ( block, component ) => {

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -18,7 +18,7 @@ const componentHandlers = [
 	require( './components/image-list.js' ),
 	require( './components/button.js' ),
 	require( './components/button-stylable.js' ),
-  require( './components/google-map.js' ),
+	require( './components/google-map.js' ),
 	require( './components/separator.js' ),
 	require( './components/anchor.js' ),
 	require( './components/tpa-widget.js' ),

--- a/packages/wxr/src/1.3/index.js
+++ b/packages/wxr/src/1.3/index.js
@@ -348,9 +348,9 @@ class WXRDriver {
 
 					if ( store === 'objects' ) {
 						const objectType = datum.type;
-
+						let output;
 						if ( objectType === 'contact-form' ) {
-							const output = [];
+							output = [];
 
 							output.push( { email: datum.data.email } );
 							for ( const field of datum.data.fields ) {
@@ -378,25 +378,27 @@ class WXRDriver {
 
 								output.push( outputObject );
 							}
-
-							this.write(
-								writer,
-								toXML(
-									{
-										_name: 'wp:object',
-										_attrs: {
-											xmlns: `http://wordpress.org/export/objects/${ objectType }/1.0/`,
-											id: datum.internalId,
-										},
-										_content: output,
-									},
-									{
-										depth: 1,
-										indent: '\t',
-									}
-								) + '\n'
-							);
+						} else {
+							output = datum.data;
 						}
+
+						this.write(
+							writer,
+							toXML(
+								{
+									_name: 'wp:object',
+									_attrs: {
+										xmlns: `http://wordpress.org/export/objects/${ objectType }/1.0/`,
+										id: datum.internalId,
+									},
+									_content: output,
+								},
+								{
+									depth: 1,
+									indent: '\t',
+								}
+							) + '\n'
+						);
 						continue;
 					}
 

--- a/packages/wxr/src/1.3/objects/index.js
+++ b/packages/wxr/src/1.3/objects/index.js
@@ -1,3 +1,4 @@
 module.exports = {
 	'contact-form': require( './contact-form.json' ),
+	map: require( './map.json' ),
 };

--- a/packages/wxr/src/1.3/objects/map.json
+++ b/packages/wxr/src/1.3/objects/map.json
@@ -1,0 +1,171 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "http://example.com/example.json",
+    "type": "object",
+    "title": "The root schema",
+    "description": "The root schema comprises the entire JSON document.",
+    "default":
+    {},
+    "required":
+    [
+        "height",
+        "width",
+        "zoom",
+        "showZoom",
+        "showPosition",
+        "showStreetView",
+        "showDirectionsLink",
+        "mapDragging",
+        "mapType",
+        "showMapType",
+        "locations"
+    ],
+    "properties":
+    {
+        "height":
+        {
+            "$id": "#/properties/height",
+            "type": "integer",
+            "title": "The height schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0
+        },
+        "width":
+        {
+            "$id": "#/properties/width",
+            "type": "integer",
+            "title": "The width schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0
+        },
+        "zoom":
+        {
+            "$id": "#/properties/zoom",
+            "type": "integer",
+            "title": "The zoom schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0
+        },
+        "showZoom":
+        {
+            "$id": "#/properties/showZoom",
+            "type": "boolean",
+            "title": "The showZoom schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": false
+        },
+        "showPosition":
+        {
+            "$id": "#/properties/showPosition",
+            "type": "boolean",
+            "title": "The showPosition schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": false
+        },
+        "showStreetView":
+        {
+            "$id": "#/properties/showStreetView",
+            "type": "boolean",
+            "title": "The showStreetView schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": false
+        },
+        "showDirectionsLink":
+        {
+            "$id": "#/properties/showDirectionsLink",
+            "type": "boolean",
+            "title": "The showDirectionsLink schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": false
+        },
+        "mapDragging":
+        {
+            "$id": "#/properties/mapDragging",
+            "type": "boolean",
+            "title": "The mapDragging schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": false
+        },
+        "mapType":
+        {
+            "$id": "#/properties/mapType",
+            "type": "string",
+            "title": "The mapType schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": ""
+        },
+        "showMapType":
+        {
+            "$id": "#/properties/showMapType",
+            "type": "boolean",
+            "title": "The showMapType schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": false
+        },
+	    "pinColor":
+		{
+			"$id": "#/properties/pinColor",
+			"type": "string",
+			"title": "The pinColor schema",
+			"description": "An explanation about the purpose of this instance.",
+			"default": ""
+		},
+        "locations":
+        {
+            "$id": "#/properties/locations",
+            "type": "array",
+            "title": "The locations schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default":
+            [],
+            "items":
+            {
+                "$id": "#/properties/locations/items",
+                "anyOf":
+                [
+                    {
+                        "$id": "#/properties/locations/items/anyOf/0",
+                        "type": "object",
+                        "title": "The first anyOf schema",
+                        "description": "An explanation about the purpose of this instance.",
+                        "default":
+                        {},
+                        "required":
+                        [
+                            "latitude",
+                            "longitude",
+                            "address"
+                        ],
+                        "properties":
+                        {
+                            "latitude":
+                            {
+                                "$id": "#/properties/locations/items/anyOf/0/properties/latitude",
+                                "type": "number",
+                                "title": "The latitude schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": 0.0
+                            },
+                            "longitude":
+                            {
+                                "$id": "#/properties/locations/items/anyOf/0/properties/longitude",
+                                "type": "number",
+                                "title": "The longitude schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": 0.0
+                            },
+                            "address":
+                            {
+                                "$id": "#/properties/locations/items/anyOf/0/properties/address",
+                                "type": "string",
+                                "title": "The address schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": ""
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Changes contain `GoogleMaps` component mapper support.

There are three types of changes:

1. Introduce Google Maps component mapper.
Since Gutenberg doesn't support the Google Maps component as a core component, it's mapped as a `core/plugin` placeholder with a regular list of attributes.

2. Update JSON schema by adding a new `map` entity.

3. Fix issues and refactor/simplify the `resolveQueires` method.
The issue with recursive handling queries have been fixed in [this commit](https://github.com/pento/free-as-in-speech/commit/815d3a9d80e1b6507ce8189f43cfdaccb047ca64) and some refactoring [here](https://github.com/pento/free-as-in-speech/commit/518479b37b940f9187391e14f5b5cb8725a0ae58) and [here](https://github.com/pento/free-as-in-speech/commit/e72cbd01daddfb0f05eab453904a46d77a9ad42a).

## How has this been tested?
It has passed manual testing:

- create a private website
- create a page with the `Google Map` component
- run the parser
- result should be a proper Gutenberg block `core/plugin` with proper mapped attributes

## Types of changes
New feature and bug fixes (non-breaking change which adds functionality)
