### PR TITLE
Await component mappers async jobs

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/image-vector.js
+++ b/packages/site-parsers/src/parsers/wix/components/image-vector.js
@@ -12,7 +12,7 @@ module.exports = {
 			'shapes/' +
 			component.dataQuery.svgId;
 
-		await axios
+		return await axios
 			.get( svgContentUrl )
 			.then( ( response ) => response.data )
 			.then( ( svgData ) => {

--- a/packages/site-parsers/src/parsers/wix/containers/column.js
+++ b/packages/site-parsers/src/parsers/wix/containers/column.js
@@ -1,15 +1,14 @@
 const { createBlock } = require( '@wordpress/blocks' );
+const { asyncComponentsParser } = require( '../data' );
 
 module.exports = {
 	componentType: 'wysiwyg.viewer.components.Column',
-	parseComponent: ( component, recursiveComponentParser ) => {
-		return createBlock(
-			'core/column',
-			{},
-			component.components
-				.map( recursiveComponentParser )
-				.flat()
-				.filter( Boolean )
+	parseComponent: async ( component, recursiveComponentParser ) => {
+		const innerComponents = await asyncComponentsParser(
+			component.components,
+			recursiveComponentParser
 		);
+
+		return createBlock( 'core/column', {}, innerComponents );
 	},
 };

--- a/packages/site-parsers/src/parsers/wix/containers/columns.js
+++ b/packages/site-parsers/src/parsers/wix/containers/columns.js
@@ -1,9 +1,13 @@
 const { createBlock } = require( '@wordpress/blocks' );
+const { asyncComponentsParser } = require( '../data' );
 
 module.exports = {
 	componentType: 'wysiwyg.viewer.components.StripColumnsContainer',
-	parseComponent: ( component, recursiveComponentParser ) => {
-		let innerBlocks = component.components.map( recursiveComponentParser );
+	parseComponent: async ( component, recursiveComponentParser ) => {
+		let innerBlocks = await asyncComponentsParser(
+			component.components,
+			recursiveComponentParser
+		);
 
 		if ( ! innerBlocks.length ) {
 			return null;
@@ -54,13 +58,11 @@ module.exports = {
 			return columnsBlock;
 		}
 
-		return createBlock(
-			'core/column',
-			{},
-			component.components
-				.map( recursiveComponentParser )
-				.flat()
-				.filter( Boolean )
+		const innerComponents = await asyncComponentsParser(
+			component.components,
+			recursiveComponentParser
 		);
+
+		return createBlock( 'core/column', {}, innerComponents );
 	},
 };

--- a/packages/site-parsers/src/parsers/wix/containers/mobile.js
+++ b/packages/site-parsers/src/parsers/wix/containers/mobile.js
@@ -1,15 +1,14 @@
 const { createBlock } = require( '@wordpress/blocks' );
+const { asyncComponentsParser } = require( '../data' );
 
 module.exports = {
 	componentType: 'mobile.core.components.Container',
-	parseComponent: ( component, recursiveComponentParser ) => {
-		return createBlock(
-			'core/group',
-			{},
-			component.components
-				.map( recursiveComponentParser )
-				.flat()
-				.filter( Boolean )
+	parseComponent: async ( component, recursiveComponentParser ) => {
+		const innerComponents = await asyncComponentsParser(
+			component.components,
+			recursiveComponentParser
 		);
+
+		return createBlock( 'core/group', {}, innerComponents );
 	},
 };

--- a/packages/site-parsers/src/parsers/wix/data.js
+++ b/packages/site-parsers/src/parsers/wix/data.js
@@ -6,7 +6,7 @@ const slug = require( 'slugify' );
 /**
  * Internal dependencies
  */
-const { IdFactory } = require( '../../utils' );
+const { asyncForEach, IdFactory } = require( '../../utils' );
 
 const getProperTreeLocation = ( fieldName ) => {
 	switch ( fieldName ) {
@@ -138,9 +138,19 @@ const getThemeDataRef = ( page, id ) => {
 	);
 };
 
+const asyncComponentsParser = async ( components, parser ) => {
+	const parserComponents = [];
+	await asyncForEach( components, async ( comp ) => {
+		parserComponents.push( await parser( comp ) );
+	} );
+
+	return parserComponents.flat().filter( Boolean );
+};
+
 module.exports = {
 	resolveQueries,
 	addMediaAttachment,
 	addObject,
 	getThemeDataRef,
+	asyncComponentsParser,
 };

--- a/packages/site-parsers/src/parsers/wix/mappers.js
+++ b/packages/site-parsers/src/parsers/wix/mappers.js
@@ -1,4 +1,5 @@
 const { pasteHandler } = require( '@wordpress/blocks' );
+const { asyncComponentsParser } = require( './data' );
 
 const handlerMapper = ( key ) => ( accumulator, currentValue ) => {
 	accumulator[ currentValue[ key ] ] = currentValue;
@@ -47,7 +48,7 @@ const getTypeFromComponentPath = ( componentType ) => {
 };
 
 module.exports = {
-	containerMapper: (
+	containerMapper: async (
 		component,
 		recursiveComponentParser,
 		resolver,
@@ -56,7 +57,9 @@ module.exports = {
 	) => {
 		if ( component.componentType in containerHandlers ) {
 			return wrapResult(
-				containerHandlers[ component.componentType ].parseComponent(
+				await containerHandlers[
+					component.componentType
+				].parseComponent(
 					component,
 					recursiveComponentParser,
 					resolver,
@@ -67,10 +70,10 @@ module.exports = {
 			);
 		}
 
-		return component.components
-			.map( recursiveComponentParser )
-			.flat()
-			.filter( Boolean );
+		return await asyncComponentsParser(
+			component.components,
+			recursiveComponentParser
+		);
 	},
 
 	componentMapper: ( component, meta ) => {


### PR DESCRIPTION
## Description
Changes introduce a fix for properly await async component parser methods.

Before the last added chunk of new mappers, we didn't have a parser that needs to fetch the data asynchronously as the case is with Html and ImageVector components. The issue was when mentioned components are placed as inner blocks.

## How has this been tested?
It has been tested manually
- create a page
- create a mobile container
- create an inner block (Html or VectorImage component) inside of the container
- inner blocks should be properly parsed

## Types of changes
Bug fix (non-breaking change which fixes an issue)
