### PR TITLE
Map missing page fields

### DIFF
--- a/packages/site-parsers/src/parsers/wix/pages.js
+++ b/packages/site-parsers/src/parsers/wix/pages.js
@@ -116,6 +116,8 @@ const parsePages = async ( data, metaData, masterPage, config ) => {
 			recursiveComponentParser
 		);
 
+		page.guid = page.url;
+		page.link = page.url;
 		page.content = serialize( parsedComponents );
 	} );
 };


### PR DESCRIPTION
## Description
Add missing page fields.

## How has this been tested?
- use FaiS package as dependency on the site-parser
- final WXR doesn't contain link and GUID fields

## Screenshots
<img width="578" alt="Markup 2021-07-07 at 15 15 02" src="https://user-images.githubusercontent.com/1241413/124765377-2eb87280-df36-11eb-86a0-6a297a19d965.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
