### PR TITLE
Fix issue with missing gallery image attachments

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/image-list.js
+++ b/packages/site-parsers/src/parsers/wix/components/image-list.js
@@ -1,17 +1,17 @@
 const { createBlock } = require( '@wordpress/blocks' );
 const { parseComponent: linkBarParseComponent } = require( './link-bar' );
 
-const parseImages = ( images, metaData ) => {
+const parseImages = ( images, { addMediaAttachment } ) => {
 	return images.map( ( img ) => {
-		const prefix = metaData.serviceTopology.staticAudioUrl;
+		const attachment = addMediaAttachment( img );
 
 		const attrs = {
-			id: img.id,
+			id: attachment.id,
 			alt: img.alt,
 			title: img.title,
 			caption: img.description,
-			url: prefix + '/' + img.uri,
-			fulUrl: '/' + prefix + '/' + img.uri,
+			url: attachment.attachment_url,
+			fulUrl: attachment.attachment_url,
 		};
 
 		if ( img.link ) {
@@ -24,8 +24,8 @@ const parseImages = ( images, metaData ) => {
 
 module.exports = {
 	type: 'ImageList',
-	parseComponent: ( component, { metaData } ) => {
-		const images = parseImages( component.dataQuery.items, metaData );
+	parseComponent: ( component, meta ) => {
+		const images = parseImages( component.dataQuery.items, meta );
 		const attrs = {
 			images,
 			ids: images.map( ( img ) => img.id ),

--- a/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
+++ b/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
@@ -158,35 +158,35 @@ exports[`wix: personal-website.har 1`] = `
 		<wp:term_name><![CDATA[tt1-blocks]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<item>
-		<wp:post_id>30</wp:post_id>
+		<wp:post_id>34</wp:post_id>
 		<title><![CDATA[Home Page]]></title>
 		<description></description>
 		<content:encoded><![CDATA[<!-- wp:paragraph -->
@@ -209,7 +209,7 @@ exports[`wix: personal-website.har 1`] = `
 <!-- wp:social-link {\\"url\\":\\"https://www.linkedin.com/company/wix-com\\",\\"service\\":\\"linkedin\\",\\"label\\":\\"LinkedIn\\"} /--></ul>
 <!-- /wp:social-links -->
 
-<!-- wp:file {\\"id\\":34,\\"href\\":\\"https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip\\"} -->
+<!-- wp:file {\\"id\\":41,\\"href\\":\\"https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip\\"} -->
 <div class=\\"wp-block-file\\"><a href=\\"Screenshot 2021-06-08 at 10.15.34.zip\\">Screenshot-2021-06-08-at-10.15.34.zip</a><a href=\\"https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip\\" class=\\"wp-block-file__button\\" download>Screenshot-2021-06-08-at-10.15.34.zip</a></div>
 <!-- /wp:file -->
 
@@ -230,11 +230,11 @@ exports[`wix: personal-website.har 1`] = `
 		<wp:is_sticky>0</wp:is_sticky>
 	</item>
 	<item>
-		<wp:post_id>31</wp:post_id>
+		<wp:post_id>35</wp:post_id>
 		<title><![CDATA[Gallery Page]]></title>
 		<description></description>
-		<content:encoded><![CDATA[<!-- wp:gallery {\\"ids\\":[\\"dataItem-bJGg3Al\\",\\"dataItem-pjYdtZX\\",\\"dataItem-c9EZbPBo\\",\\"dataItem-ix8o1r0W\\"]} -->
-<figure class=\\"wp-block-gallery columns-3 is-cropped\\"><ul class=\\"blocks-gallery-grid\\"><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://music.wixstatic.com/mp3/v2RHz_ZlMU0yd1JEYcA5J4uvA2zA9rbrjsKoc~mv2_d_3000_2930_s_4_2.jpg\\" alt=\\"\\" data-id=\\"dataItem-bJGg3Al\\" class=\\"wp-image-dataItem-bJGg3Al\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://music.wixstatic.com/mp3/XZKol_LAhGy0RqaBgitZJJLW6RnMHlSiKXUEn~mv2_d_3000_1946_s_2.jpg\\" alt=\\"\\" data-id=\\"dataItem-pjYdtZX\\" class=\\"wp-image-dataItem-pjYdtZX\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://music.wixstatic.com/mp3/X84P2_eLeeOFhl0dTWnhLv81eFGp4oulwfpSf~mv2_d_3000_1965_s_2.jpg\\" alt=\\"\\" data-id=\\"dataItem-c9EZbPBo\\" class=\\"wp-image-dataItem-c9EZbPBo\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://music.wixstatic.com/mp3/i1QDX_dWMHQcXZv2CwUmAgmWWSJ9LOSAovE0b~mv2_d_3000_1995_s_2.jpg\\" alt=\\"\\" data-id=\\"dataItem-ix8o1r0W\\" class=\\"wp-image-dataItem-ix8o1r0W\\"/></figure></li></ul></figure>
+		<content:encoded><![CDATA[<!-- wp:gallery {\\"ids\\":[42,43,44,45]} -->
+<figure class=\\"wp-block-gallery columns-3 is-cropped\\"><ul class=\\"blocks-gallery-grid\\"><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/v2RHz_ZlMU0yd1JEYcA5J4uvA2zA9rbrjsKoc~mv2_d_3000_2930_s_4_2.jpg\\" alt=\\"\\" data-id=\\"42\\" class=\\"wp-image-42\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/XZKol_LAhGy0RqaBgitZJJLW6RnMHlSiKXUEn~mv2_d_3000_1946_s_2.jpg\\" alt=\\"\\" data-id=\\"43\\" class=\\"wp-image-43\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/X84P2_eLeeOFhl0dTWnhLv81eFGp4oulwfpSf~mv2_d_3000_1965_s_2.jpg\\" alt=\\"\\" data-id=\\"44\\" class=\\"wp-image-44\\"/></figure></li><li class=\\"blocks-gallery-item\\"><figure><img src=\\"https://static.wixstatic.com/media/i1QDX_dWMHQcXZv2CwUmAgmWWSJ9LOSAovE0b~mv2_d_3000_1995_s_2.jpg\\" alt=\\"\\" data-id=\\"45\\" class=\\"wp-image-45\\"/></figure></li></ul></figure>
 <!-- /wp:gallery -->]]></content:encoded>
 		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
 		<wp:status><![CDATA[publish]]></wp:status>
@@ -242,7 +242,7 @@ exports[`wix: personal-website.har 1`] = `
 		<wp:is_sticky>0</wp:is_sticky>
 	</item>
 	<item>
-		<wp:post_id>32</wp:post_id>
+		<wp:post_id>36</wp:post_id>
 		<title><![CDATA[Media Page]]></title>
 		<description></description>
 		<content:encoded><![CDATA[<!-- wp:heading -->
@@ -276,7 +276,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		<wp:is_sticky>0</wp:is_sticky>
 	</item>
 	<item>
-		<wp:post_id>33</wp:post_id>
+		<wp:post_id>37</wp:post_id>
 		<title><![CDATA[Additional components]]></title>
 		<description></description>
 		<content:encoded><![CDATA[<!-- wp:image {\\"width\\":2590,\\"height\\":1574} -->
@@ -503,7 +503,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		<category domain=\\"wp_theme\\" nicename=\\"wp_theme\\">tt1-blocks</category>
 	</item>
 	<item>
-		<wp:post_id>36</wp:post_id>
+		<wp:post_id>48</wp:post_id>
 		<title><![CDATA[Home Page]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -519,7 +519,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object_id</wp:meta_key>
-			<wp:meta_value>30</wp:meta_value>
+			<wp:meta_value>34</wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object</wp:meta_key>
@@ -527,7 +527,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>37</wp:post_id>
+		<wp:post_id>49</wp:post_id>
 		<title><![CDATA[Media Page]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -543,7 +543,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object_id</wp:meta_key>
-			<wp:meta_value>32</wp:meta_value>
+			<wp:meta_value>36</wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object</wp:meta_key>
@@ -551,7 +551,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>38</wp:post_id>
+		<wp:post_id>50</wp:post_id>
 		<title><![CDATA[Gallery Page]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -567,7 +567,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object_id</wp:meta_key>
-			<wp:meta_value>31</wp:meta_value>
+			<wp:meta_value>35</wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object</wp:meta_key>
@@ -575,7 +575,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>39</wp:post_id>
+		<wp:post_id>51</wp:post_id>
 		<title><![CDATA[Additional components]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -591,7 +591,7 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object_id</wp:meta_key>
-			<wp:meta_value>33</wp:meta_value>
+			<wp:meta_value>37</wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object</wp:meta_key>
@@ -599,7 +599,58 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>34</wp:post_id>
+		<wp:post_id>38</wp:post_id>
+		<title><![CDATA[Facebook]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/0fdef751204647a3bbd7eaa2827ed4f9.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/0fdef751204647a3bbd7eaa2827ed4f9.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/0fdef751204647a3bbd7eaa2827ed4f9.png]]></wp:attachment_url>
+		<wp:postmeta>
+			<wp:meta_key>_wp_attachment_attachment_alt</wp:meta_key>
+			<wp:meta_value>Facebook</wp:meta_value>
+		</wp:postmeta>
+	</item>
+	<item>
+		<wp:post_id>39</wp:post_id>
+		<title><![CDATA[Twitter]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/c7d035ba85f6486680c2facedecdcf4d.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/c7d035ba85f6486680c2facedecdcf4d.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/c7d035ba85f6486680c2facedecdcf4d.png]]></wp:attachment_url>
+		<wp:postmeta>
+			<wp:meta_key>_wp_attachment_attachment_alt</wp:meta_key>
+			<wp:meta_value>Twitter</wp:meta_value>
+		</wp:postmeta>
+	</item>
+	<item>
+		<wp:post_id>40</wp:post_id>
+		<title><![CDATA[LinkedIn]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/6ea5b4a88f0b4f91945b40499aa0af00.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/6ea5b4a88f0b4f91945b40499aa0af00.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/6ea5b4a88f0b4f91945b40499aa0af00.png]]></wp:attachment_url>
+		<wp:postmeta>
+			<wp:meta_key>_wp_attachment_attachment_alt</wp:meta_key>
+			<wp:meta_value>LinkedIn</wp:meta_value>
+		</wp:postmeta>
+	</item>
+	<item>
+		<wp:post_id>41</wp:post_id>
 		<title><![CDATA[Screenshot 2021-06-08 at 10.15.34.zip]]></title>
 		<link><![CDATA[https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></link>
 		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></guid>
@@ -616,7 +667,59 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>35</wp:post_id>
+		<wp:post_id>42</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/v2RHz_ZlMU0yd1JEYcA5J4uvA2zA9rbrjsKoc~mv2_d_3000_2930_s_4_2.jpg]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/v2RHz_ZlMU0yd1JEYcA5J4uvA2zA9rbrjsKoc~mv2_d_3000_2930_s_4_2.jpg]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/v2RHz_ZlMU0yd1JEYcA5J4uvA2zA9rbrjsKoc~mv2_d_3000_2930_s_4_2.jpg]]></wp:attachment_url>
+	</item>
+	<item>
+		<wp:post_id>43</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/XZKol_LAhGy0RqaBgitZJJLW6RnMHlSiKXUEn~mv2_d_3000_1946_s_2.jpg]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/XZKol_LAhGy0RqaBgitZJJLW6RnMHlSiKXUEn~mv2_d_3000_1946_s_2.jpg]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/XZKol_LAhGy0RqaBgitZJJLW6RnMHlSiKXUEn~mv2_d_3000_1946_s_2.jpg]]></wp:attachment_url>
+	</item>
+	<item>
+		<wp:post_id>44</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/X84P2_eLeeOFhl0dTWnhLv81eFGp4oulwfpSf~mv2_d_3000_1965_s_2.jpg]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/X84P2_eLeeOFhl0dTWnhLv81eFGp4oulwfpSf~mv2_d_3000_1965_s_2.jpg]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/X84P2_eLeeOFhl0dTWnhLv81eFGp4oulwfpSf~mv2_d_3000_1965_s_2.jpg]]></wp:attachment_url>
+	</item>
+	<item>
+		<wp:post_id>45</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/i1QDX_dWMHQcXZv2CwUmAgmWWSJ9LOSAovE0b~mv2_d_3000_1995_s_2.jpg]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/i1QDX_dWMHQcXZv2CwUmAgmWWSJ9LOSAovE0b~mv2_d_3000_1995_s_2.jpg]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/i1QDX_dWMHQcXZv2CwUmAgmWWSJ9LOSAovE0b~mv2_d_3000_1995_s_2.jpg]]></wp:attachment_url>
+	</item>
+	<item>
+		<wp:post_id>46</wp:post_id>
 		<title><![CDATA[Screenshot 2021-06-20 at 17.14.01.png]]></title>
 		<link><![CDATA[https://static.wixstatic.com/media/62xMl_5qDOShg8nxX0fEzuSb1e0wDcmBWdfiA~mv2.png]]></link>
 		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/62xMl_5qDOShg8nxX0fEzuSb1e0wDcmBWdfiA~mv2.png]]></guid>
@@ -631,6 +734,19 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 			<wp:meta_key>_wp_attachment_attachment_alt</wp:meta_key>
 			<wp:meta_value>Screenshot 2021-06-20 at 17.14.01.png</wp:meta_value>
 		</wp:postmeta>
+	</item>
+	<item>
+		<wp:post_id>47</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/63f140fc5a154a20af32ac5e5c5f734e.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/63f140fc5a154a20af32ac5e5c5f734e.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/63f140fc5a154a20af32ac5e5c5f734e.png]]></wp:attachment_url>
 	</item>
 
 	<wp:object xmlns=\\"http://wordpress.org/export/objects/map/1.0/\\" id=\\"1\\">
@@ -721,35 +837,35 @@ exports[`wix: rockfield.har 1`] = `
 		<wp:term_name><![CDATA[tt1-blocks]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
 		<wp:term_name><![CDATA[Custom Main Menu]]></wp:term_name>
 	</wp:term>
 	<wp:term>
-		<wp:term_id>21</wp:term_id>
+		<wp:term_id>25</wp:term_id>
 		<wp:term_taxonomy><![CDATA[nav_menu]]></wp:term_taxonomy>
 		<wp:term_slug><![CDATA[custom-main-menu-1]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
@@ -1464,7 +1580,7 @@ exports[`wix: rockfield.har 1`] = `
 		<category domain=\\"wp_theme\\" nicename=\\"wp_theme\\">tt1-blocks</category>
 	</item>
 	<item>
-		<wp:post_id>22</wp:post_id>
+		<wp:post_id>26</wp:post_id>
 		<title><![CDATA[Home]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -1488,7 +1604,7 @@ exports[`wix: rockfield.har 1`] = `
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>23</wp:post_id>
+		<wp:post_id>27</wp:post_id>
 		<title><![CDATA[Menu]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -1512,12 +1628,12 @@ exports[`wix: rockfield.har 1`] = `
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>24</wp:post_id>
+		<wp:post_id>28</wp:post_id>
 		<title><![CDATA[Winter Menu]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:status><![CDATA[publish]]></wp:status>
-		<wp:post_parent>23</wp:post_parent>
+		<wp:post_parent>27</wp:post_parent>
 		<wp:menu_order>2</wp:menu_order>
 		<wp:post_type><![CDATA[nav_menu_item]]></wp:post_type>
 		<wp:is_sticky>0</wp:is_sticky>
@@ -1528,7 +1644,7 @@ exports[`wix: rockfield.har 1`] = `
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_menu_item_parent</wp:meta_key>
-			<wp:meta_value>23</wp:meta_value>
+			<wp:meta_value>27</wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_menu_item_object_id</wp:meta_key>
@@ -1540,7 +1656,7 @@ exports[`wix: rockfield.har 1`] = `
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>27</wp:post_id>
+		<wp:post_id>31</wp:post_id>
 		<title><![CDATA[What's On]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -1564,7 +1680,7 @@ exports[`wix: rockfield.har 1`] = `
 		</wp:postmeta>
 	</item>
 	<item>
-		<wp:post_id>28</wp:post_id>
+		<wp:post_id>32</wp:post_id>
 		<title><![CDATA[Reservations]]></title>
 		<description></description>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
@@ -1705,6 +1821,58 @@ exports[`wix: rockfield.har 1`] = `
 			<wp:meta_key>_wp_attachment_attachment_alt</wp:meta_key>
 			<wp:meta_value>appetizer-blurred-background-cheese-2531</wp:meta_value>
 		</wp:postmeta>
+	</item>
+	<item>
+		<wp:post_id>21</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/23fd2a2be53141ed810f4d3dcdcd01fa.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/23fd2a2be53141ed810f4d3dcdcd01fa.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/23fd2a2be53141ed810f4d3dcdcd01fa.png]]></wp:attachment_url>
+	</item>
+	<item>
+		<wp:post_id>22</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/81af6121f84c41a5b4391d7d37fce12a.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/81af6121f84c41a5b4391d7d37fce12a.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/81af6121f84c41a5b4391d7d37fce12a.png]]></wp:attachment_url>
+	</item>
+	<item>
+		<wp:post_id>23</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/K0Ow9_SjhnaWI4tshShXnoC20C8EqVy2lRTVG~mv2.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/K0Ow9_SjhnaWI4tshShXnoC20C8EqVy2lRTVG~mv2.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/K0Ow9_SjhnaWI4tshShXnoC20C8EqVy2lRTVG~mv2.png]]></wp:attachment_url>
+	</item>
+	<item>
+		<wp:post_id>24</wp:post_id>
+		<title><![CDATA[]]></title>
+		<link><![CDATA[https://static.wixstatic.com/media/3ae0375b94ba46fca1f4e6c0f7992fc9.png]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/3ae0375b94ba46fca1f4e6c0f7992fc9.png]]></guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/3ae0375b94ba46fca1f4e6c0f7992fc9.png]]></wp:attachment_url>
 	</item>
 </channel>
 </rss>"


### PR DESCRIPTION
## Description
The changes contain missing logic to create media attachments while parsing the ImageList component.

## How has this been tested?
- create a page with the gallery component
- run the extension
- export the WXR
- got to WP site and then import
- media page should contain gallery images

## Types of changes
Bug fix (non-breaking change which fixes an issue)
