### PR TITLE
Fix document media URL

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/document-media.js
+++ b/packages/site-parsers/src/parsers/wix/components/document-media.js
@@ -10,14 +10,15 @@ module.exports = {
 			return null;
 		}
 
-		const attachment = addMediaAttachment(
-			metaData.serviceTopology.staticHTMLComponentUrl,
-			{
-				uri: component.dataQuery.link.docId,
-				name: component.dataQuery.link.name,
-				alt: component.dataQuery.link.name,
-			}
+		const mediaUrl = metaData.serviceTopology.staticHTMLComponentUrl.replace(
+			/\/$/,
+			''
 		);
+		const attachment = addMediaAttachment( mediaUrl, {
+			uri: component.dataQuery.link.docId,
+			name: component.dataQuery.link.name,
+			alt: component.dataQuery.link.name,
+		} );
 
 		return createBlock( 'core/file', {
 			id: attachment.id,

--- a/packages/site-parsers/src/parsers/wix/components/document-media.js
+++ b/packages/site-parsers/src/parsers/wix/components/document-media.js
@@ -10,15 +10,14 @@ module.exports = {
 			return null;
 		}
 
-		const mediaUrl = metaData.serviceTopology.staticHTMLComponentUrl.replace(
-			/\/$/,
-			''
+		const attachment = addMediaAttachment(
+			metaData.serviceTopology.staticHTMLComponentUrl,
+			{
+				uri: component.dataQuery.link.docId,
+				name: component.dataQuery.link.name,
+				alt: component.dataQuery.link.name,
+			}
 		);
-		const attachment = addMediaAttachment( mediaUrl, {
-			uri: component.dataQuery.link.docId,
-			name: component.dataQuery.link.name,
-			alt: component.dataQuery.link.name,
-		} );
 
 		return createBlock( 'core/file', {
 			id: attachment.id,

--- a/packages/site-parsers/src/parsers/wix/components/document-media.js
+++ b/packages/site-parsers/src/parsers/wix/components/document-media.js
@@ -15,7 +15,7 @@ module.exports = {
 			{
 				uri: component.dataQuery.link.docId,
 				name: component.dataQuery.link.name,
-				alt: component.dataQuery.title,
+				alt: component.dataQuery.link.name,
 			}
 		);
 

--- a/packages/site-parsers/src/parsers/wix/components/document-media.js
+++ b/packages/site-parsers/src/parsers/wix/components/document-media.js
@@ -5,16 +5,19 @@ const { createBlock } = require( '@wordpress/blocks' );
  * componentType: DocumentMedia
  */
 module.exports = {
-	parseComponent: ( component, { addMediaAttachment } ) => {
+	parseComponent: ( component, { metaData, addMediaAttachment } ) => {
 		if ( ! component.dataQuery.link ) {
 			return null;
 		}
 
-		const attachment = addMediaAttachment( {
-			uri: component.dataQuery.link.docId,
-			name: component.dataQuery.link.name,
-			alt: component.dataQuery.title,
-		} );
+		const attachment = addMediaAttachment(
+			metaData.serviceTopology.staticHTMLComponentUrl,
+			{
+				uri: component.dataQuery.link.docId,
+				name: component.dataQuery.link.name,
+				alt: component.dataQuery.title,
+			}
+		);
 
 		return createBlock( 'core/file', {
 			id: attachment.id,

--- a/packages/site-parsers/src/parsers/wix/components/image-list.js
+++ b/packages/site-parsers/src/parsers/wix/components/image-list.js
@@ -1,9 +1,12 @@
 const { createBlock } = require( '@wordpress/blocks' );
 const { parseComponent: linkBarParseComponent } = require( './link-bar' );
 
-const parseImages = ( images, { addMediaAttachment } ) => {
+const parseImages = ( images, { metaData, addMediaAttachment } ) => {
 	return images.map( ( img ) => {
-		const attachment = addMediaAttachment( img );
+		const attachment = addMediaAttachment(
+			metaData.serviceTopology.staticMediaUrl,
+			img
+		);
 
 		const attrs = {
 			id: attachment.id,

--- a/packages/site-parsers/src/parsers/wix/components/image.js
+++ b/packages/site-parsers/src/parsers/wix/components/image.js
@@ -1,12 +1,15 @@
 const { createBlock } = require( '@wordpress/blocks' );
 const { parseComponent: parseDocumentMedia } = require( './document-media' );
 
-const parseImage = ( component, { addMediaAttachment } ) => {
+const parseImage = ( component, { metaData, addMediaAttachment } ) => {
 	if ( ! component.dataQuery || ! component.dataQuery.uri ) {
 		return null;
 	}
 
-	const attachment = addMediaAttachment( component.dataQuery );
+	const attachment = addMediaAttachment(
+		metaData.serviceTopology.staticMediaUrl,
+		component.dataQuery
+	);
 
 	return createBlock( 'core/image', {
 		url: attachment.guid,

--- a/packages/site-parsers/src/parsers/wix/containers/cover.js
+++ b/packages/site-parsers/src/parsers/wix/containers/cover.js
@@ -1,7 +1,7 @@
 const { createBlock } = require( '@wordpress/blocks' );
 
 module.exports = {
-	maybeAddCoverBlock: ( component, { addMediaAttachment } ) => {
+	maybeAddCoverBlock: ( component, { metaData, addMediaAttachment } ) => {
 		if ( ! component || ! component.innerBlocks ) {
 			return component;
 		}
@@ -18,6 +18,7 @@ module.exports = {
 		) {
 			// If a background is defined, let's make this a cover block.
 			const attachment = addMediaAttachment(
+				metaData.serviceTopology.staticMediaUrl,
 				component.designQuery.background.mediaRef
 			);
 

--- a/packages/site-parsers/src/parsers/wix/data.js
+++ b/packages/site-parsers/src/parsers/wix/data.js
@@ -94,6 +94,8 @@ const addMediaAttachment = ( data, mediaUrl, component ) => {
 	if ( existingId ) {
 		return data.attachments[ existingId ];
 	}
+
+	mediaUrl = mediaUrl.replace( /\/$/, '' );
 	component.src = mediaUrl + '/' + component.uri;
 
 	const attachment = {

--- a/packages/site-parsers/src/parsers/wix/pages.js
+++ b/packages/site-parsers/src/parsers/wix/pages.js
@@ -85,11 +85,7 @@ const parsePages = async ( data, metaData, masterPage, config ) => {
 			page,
 			fetch: config.fetch,
 			addObject: addObject.bind( null, data ),
-			addMediaAttachment: addMediaAttachment.bind(
-				null,
-				data,
-				metaData.serviceTopology.staticMediaUrl
-			),
+			addMediaAttachment: addMediaAttachment.bind( null, data ),
 			getThemeDataRef: getThemeDataRef.bind( null, page ),
 		};
 

--- a/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
+++ b/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
@@ -209,8 +209,8 @@ exports[`wix: personal-website.har 1`] = `
 <!-- wp:social-link {\\"url\\":\\"https://www.linkedin.com/company/wix-com\\",\\"service\\":\\"linkedin\\",\\"label\\":\\"LinkedIn\\"} /--></ul>
 <!-- /wp:social-links -->
 
-<!-- wp:file {\\"id\\":41,\\"href\\":\\"https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip\\"} -->
-<div class=\\"wp-block-file\\"><a href=\\"Screenshot 2021-06-08 at 10.15.34.zip\\">Screenshot-2021-06-08-at-10.15.34.zip</a><a href=\\"https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip\\" class=\\"wp-block-file__button\\" download>Screenshot-2021-06-08-at-10.15.34.zip</a></div>
+<!-- wp:file {\\"id\\":41,\\"href\\":\\"https://006852ac-032b-4153-bc06-0df0e4601f93.filesusr.com/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip\\"} -->
+<div class=\\"wp-block-file\\"><a href=\\"Screenshot 2021-06-08 at 10.15.34.zip\\">Screenshot-2021-06-08-at-10.15.34.zip</a><a href=\\"https://006852ac-032b-4153-bc06-0df0e4601f93.filesusr.com/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip\\" class=\\"wp-block-file__button\\" download>Screenshot-2021-06-08-at-10.15.34.zip</a></div>
 <!-- /wp:file -->
 
 <!-- wp:social-links {\\"openInNewTab\\":true} -->
@@ -652,15 +652,15 @@ https://soundcloud.com/samiran-saharia/tales-from-the-other-sideoriginal-mix
 	<item>
 		<wp:post_id>41</wp:post_id>
 		<title><![CDATA[Screenshot 2021-06-08 at 10.15.34.zip]]></title>
-		<link><![CDATA[https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></link>
-		<guid isPermaLink=\\"false\\"><![CDATA[https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></guid>
+		<link><![CDATA[https://006852ac-032b-4153-bc06-0df0e4601f93.filesusr.com/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></link>
+		<guid isPermaLink=\\"false\\"><![CDATA[https://006852ac-032b-4153-bc06-0df0e4601f93.filesusr.com/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:post_type><![CDATA[attachment]]></wp:post_type>
 		<wp:is_sticky>0</wp:is_sticky>
-		<wp:attachment_url><![CDATA[https://static.wixstatic.com/media/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></wp:attachment_url>
+		<wp:attachment_url><![CDATA[https://006852ac-032b-4153-bc06-0df0e4601f93.filesusr.com/archives/5Ol1G_VEb0f9Q4TK3HuLndMIfNdLwH1G3Cwp6.zip]]></wp:attachment_url>
 		<wp:postmeta>
 			<wp:meta_key>_wp_attachment_attachment_alt</wp:meta_key>
 			<wp:meta_value>Screenshot 2021-06-08 at 10.15.34.zip</wp:meta_value>


### PR DESCRIPTION
## Description
The changes provide:
- `addMediaAttachment` method adjustment allowing to provide mediaUrl as param
- provide proper base URL for the DocumentMedia component
- update test snapshots

## How has this been tested?
- create a page with a `Document` component
- WXR extension export and then WP import
- media page should contain attached document

## Types of changes
Bug fix (non-breaking change which fixes an issue)
