### PR TITLE
Fix spotify URL

### DIFF
--- a/packages/site-parsers/src/parsers/wix/components/spotify.js
+++ b/packages/site-parsers/src/parsers/wix/components/spotify.js
@@ -1,5 +1,13 @@
 const { createBlock } = require( '@wordpress/blocks' );
 
+const getSpotifyUrlFromUri = ( uri ) => {
+	const uriRgx = /^spotify:(?<type>track|user|artist|album|playlist):(?<id>[a-zA-Z0-9]+)$/;
+	if ( ! uriRgx.test( uri ) ) return uri;
+
+	const uriMatch = uri.match( uriRgx );
+	return `https://open.spotify.com/${ uriMatch.groups.type }/${ uriMatch.groups.id }`;
+};
+
 module.exports = {
 	parseComponent: ( component ) => {
 		const tpaData = component.dataQuery.tpaData;
@@ -8,7 +16,7 @@ module.exports = {
 			const content = JSON.parse( tpaData.content );
 
 			return createBlock( 'core/embed', {
-				url: content.spotifyURI,
+				url: getSpotifyUrlFromUri( content.spotifyURI ),
 			} );
 		}
 	},

--- a/packages/site-parsers/src/parsers/wix/components/tpa-widget.js
+++ b/packages/site-parsers/src/parsers/wix/components/tpa-widget.js
@@ -3,6 +3,7 @@ const { parseComponent: parseSoundCloud } = require( './sound-cloud' );
 
 const APP_ID = {
 	SPOTIFY: '2575',
+	SPOTIFY2: '4909',
 	WIX_MUSIC: '1662',
 	SOUND_CLOUD: '3195',
 };
@@ -13,6 +14,7 @@ module.exports = {
 	parseComponent: function ( component ) {
 		switch ( component.dataQuery.applicationId ) {
 			case APP_ID.SPOTIFY:
+			case APP_ID.SPOTIFY2:
 				return parseSpotify( ...arguments );
 			case APP_ID.SOUND_CLOUD:
 				return parseSoundCloud( ...arguments );

--- a/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
+++ b/test/integration/wix/__snapshots__/fetch-from-wix-har.test.js.snap
@@ -259,9 +259,9 @@ https://dai.ly/k3jznaTlT1RbXjwkuYx
 <figure class=\\"wp-block-audio\\"><audio controls src=\\"https://music.wixstatic.com/mp3/dmPSv_DPcDH86Ium3LCRu4N4jYKKCQrhgTVsy.mp3\\"></audio></figure>
 <!-- /wp:audio -->
 
-<!-- wp:embed {\\"url\\":\\"spotify:playlist:37i9dQZF1E4lCYovezyEZT\\"} -->
+<!-- wp:embed {\\"url\\":\\"https://open.spotify.com/playlist/37i9dQZF1E4lCYovezyEZT\\"} -->
 <figure class=\\"wp-block-embed\\"><div class=\\"wp-block-embed__wrapper\\">
-spotify:playlist:37i9dQZF1E4lCYovezyEZT
+https://open.spotify.com/playlist/37i9dQZF1E4lCYovezyEZT
 </div></figure>
 <!-- /wp:embed -->
 


### PR DESCRIPTION
## Description
The changes contain logic for transforming Spotify URI to the valid URL.

You can check the [regex visualization](https://regexper.com/#%5Espotify%3A%28track%7Cuser%7Cartist%7Calbum%7Cplaylist%29%3A%28%5Ba-zA-Z0-9%5D%2B%29%24).

## How has this been tested?
- create a page with Spotify component
- WXR extension export and then WP import
- the Gutenberg page editor should properly show the Spotify component

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)
