### PR TITLE
Fix resolving null or undefined input values

### DIFF
--- a/packages/site-parsers/src/parsers/wix/data.js
+++ b/packages/site-parsers/src/parsers/wix/data.js
@@ -34,7 +34,7 @@ const isDocumentRefValid = ( refStr ) => {
 
 const resolveQueries = ( input, data, masterPage ) => {
 	// skip resolving for non-objects
-	if ( typeof input !== 'object' ) {
+	if ( ! input || typeof input !== 'object' ) {
 		return input;
 	}
 


### PR DESCRIPTION
## Description
Fixed issue with resolving falsy value as an input.

Before the change, there was a check `typeof input !== 'object'`. There are cases where the input value is `null` or `undefined` which is an `object` type, so we have a false positive statement.

<!-- Please describe what you have changed or added -->

## How has this been tested?
Test plan and manual check.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
